### PR TITLE
Fix tag_exists when jq fails to extract tags

### DIFF
--- a/tag_exists
+++ b/tag_exists
@@ -9,8 +9,9 @@ API=https://quay.io/v2
 NAME="$1"
 TAG=$(cat "$NAME"/TAG)
 TOKEN=$(curl -s -H 'Accept-Encoding: application/json' -u "$QUAY_USER:$QUAY_PASSWORD" "$API/auth?service=quay.io&scope=repository:cybozu/$NAME:pull" | jq -r .token)
+TAGS=$(curl -s -H 'Accept-Encoding: application/json' -H "Authorization: Bearer $TOKEN" "$API/cybozu/$NAME/tags/list" | jq -r '.tags[]')
 
-for t in $(curl -s -H 'Accept-Encoding: application/json' -H "Authorization: Bearer $TOKEN" "$API/cybozu/$NAME/tags/list" | jq -r '.tags[]'); do
+for t in $TAGS; do
     if [ "$t" = "$TAG" ]; then
         echo "ok"
         exit 0


### PR DESCRIPTION
/bin/sh does not exit if jq is used in for expression like this:

    for t in $(curl ... | jq '.tags[]'); do ...; done

To avoid this case, tags are first assigned to $TAGS variable.