### PR TITLE
[circleci] skip pushing branch tags for pre-releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,10 @@ jobs:
                 TAG=$(cat $d/TAG)
                 docker tag quay.io/cybozu/${d}:latest quay.io/cybozu/${d}:$TAG
                 docker push quay.io/cybozu/${d}:$TAG
+                if ! echo $TAG | grep -q -e - ; then
+                    echo ===== Skip pushing branch tags for pre-release $TAG =====
+                    continue
+                fi
                 if [ -f $d/BRANCH ]; then
                     BRANCH=$(cat $d/BRANCH)
                     docker tag quay.io/cybozu/${d}:$TAG quay.io/cybozu/${d}:$BRANCH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
                 TAG=$(cat $d/TAG)
                 docker tag quay.io/cybozu/${d}:latest quay.io/cybozu/${d}:$TAG
                 docker push quay.io/cybozu/${d}:$TAG
-                if ! echo $TAG | grep -q -e - ; then
+                if echo $TAG | grep -q -e - ; then
                     echo ===== Skip pushing branch tags for pre-release $TAG =====
                     continue
                 fi

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ CircleCI does the following each time commits are pushed to a branch.
 1. If the branch is `master`, for each directory with a built image:
     1. Tag the built image with tag in `TAG` file.
     1. Push the tagged image to quay.io.
+    1. If `TAG` represents a pre-release such as `1.2-rc.1`, continue to the  next directory.
     1. If the directory contains `BRANCH` file:
         1. Tag the built image with tag in `BRANCH` file.
         1. Push the tagged image to quay.io.


### PR DESCRIPTION
Pre-release images are not official ones therefore should
not update branch tags.  Pre-releases can be identified by
detecting "-" in the tag string.