### PR TITLE
fix tag_exists

### DIFF
--- a/tag_exists
+++ b/tag_exists
@@ -5,17 +5,14 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
-API=https://quay.io/v2
+API=https://quay.io/api/v1
 NAME="$1"
 TAG=$(cat "$NAME"/TAG)
-TOKEN=$(curl -s -H 'Accept-Encoding: application/json' -u "$QUAY_USER:$QUAY_PASSWORD" "$API/auth?service=quay.io&scope=repository:cybozu/$NAME:pull" | jq -r .token)
-TAGS=$(curl -s -H 'Accept-Encoding: application/json' -H "Authorization: Bearer $TOKEN" "$API/cybozu/$NAME/tags/list" | jq -r '.tags[]')
+STATUS=$(curl -s "$API/repository/cybozu/$NAME/tag/$TAG/images" -o /dev/null -w '%{http_code}\n')
 
-for t in $TAGS; do
-    if [ "$t" = "$TAG" ]; then
-        echo "ok"
-        exit 0
-    fi
-done
+if [ "$STATUS" = "200" ]; then
+    echo "ok"
+    exit 0
+fi
 
 echo "ng"


### PR DESCRIPTION
use quay.io v1 API instead of v2.

* setup-hw is no longer public, no authentication is necessary.
* if the number of tags exceeds 50, v2 /tags/list API needs pagination. v1 /tags API can simply confirm existence of a tag.