### PR TITLE
[argocd] Bump version to 1.2.0-rc2

### DIFF
--- a/argocd/Dockerfile
+++ b/argocd/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -sSLf https://github.com/gobuffalo/packr/releases/download/v${PACKR_VER
 
 # Install kubectl
 # NOTE: keep the version synced with https://storage.googleapis.com/kubernetes-release/release/stable.txt
-ENV KUBECTL_VERSION=1.14.3
+ENV KUBECTL_VERSION=1.15.3
 RUN curl -sSLf -o /usr/local/bin/kubectl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
@@ -30,14 +30,14 @@ RUN curl -sSLf https://github.com/ksonnet/ksonnet/releases/download/v${KSONNET_V
     mv /tmp/ks_${KSONNET_VERSION}_linux_amd64/ks /usr/local/bin/ks
 
 # Install kustomize
-ENV KUSTOMIZE_VERSION=2.0.3
+ENV KUSTOMIZE_VERSION=3.1.0
 RUN curl -sSLf -o /usr/local/bin/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64 && \
     chmod +x /usr/local/bin/kustomize
 
 
 # Stage2; Argo CD Build Stage
 FROM quay.io/cybozu/golang:1.12-bionic AS argocd-build
-ENV ARGOCD_VERSION=1.1.0-rc1
+ENV ARGOCD_VERSION=1.2.0-rc2
 ENV PACKAGE=github.com/argoproj/argo-cd
 
 COPY --from=builder /usr/local/bin/dep /usr/local/bin/dep


### PR DESCRIPTION
Also updates built-in components as follows:

- kubectl -> 1.15.3
- kustomize -> 3.1.0