### PR TITLE
Make job names unique

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,73 +161,106 @@ workflows:
     jobs:
       - scripts-cke-tools
       - build-go-sources:
+          name: build-go-sources-cke-tools
           directory: cke-tools/src
       - build-go-sources:
+          name: build-go-sources-testhttpd
           directory: testhttpd/src
       - build-go-sources:
+          name: build-go-sources-machines-endpoints
           directory: machines-endpoints/pkg/machines-endpoints
       - build-go-sources:
+          name: build-go-sources-restrictpkg
           directory: golang/restrictpkg
       - build:
+          name: build-argocd
           container-image: argocd
       - build:
+          name: build-bird
           container-image: bird
       - build:
+          name: build-calico
           container-image: calico
       - build:
+          name: build-cert-manager
           container-image: cert-manager
       - build:
+          name: build-chrony
           container-image: chrony
       - build:
+          name: build-cke-tools
           container-image: cke-tools
       - build:
+          name: buiild-contour
           container-image: contour
       - build:
+          name: build-coredns
           container-image: coredns
       - build:
+          name: build-dnsmasq
           container-image: dnsmasq
       - build-envoy:
           version: 1.11.1
       - build:
+          name: build-envoy-container
           container-image: envoy
           attach: true
           requires:
             - build-envoy
       - build:
+          name: build-etcd
           container-image: etcd
       - build:
+          name: build-external-dns
           container-image: external-dns
       - build:
+          name: build-gatekeeper
           container-image: gatekeeper
       - build:
+          name: build-golang
           container-image: golang
       - build:
+          name: build-grafana
           container-image: grafana
       - build:
+          name: build-hyperkube
           container-image: hyperkube
       - build:
+          name: build-kind-node
           container-image: kind-node
       - build:
+          name: build-kube-state-metrics
           container-image: kube-state-metrics
       - build:
+          name: build-machines-endpoints
           container-image: machines-endpoints
       - build:
+          name: build-metallb
           container-image: metallb
       - build:
+          name: build-pause
           container-image: pause
       - build:
+          name: build-prometheus
           container-image: prometheus
       - build:
+          name: build-redis
           container-image: redis
       - build:
+          name: build-serf
           container-image: serf
       - build:
+          name: build-squid
           container-image: squid
       - build:
+          name: build-teleport
           container-image: teleport
       - build:
+          name: build-testhttpd
           container-image: testhttpd
       - build:
+          name: build-unbound
           container-image: unbound
       - build:
+          name: build-vault
           container-image: vault


### PR DESCRIPTION
To improve the list of CI jobs, add `name` field to each `build` job.

- before: https://github.com/cybozu/neco-containers/runs/241000589
- after: https://github.com/cybozu/neco-containers/runs/241026600