### PR TITLE
moco-mysql: reduce COPY in Dockerfile

### DIFF
--- a/moco-mysql/Dockerfile
+++ b/moco-mysql/Dockerfile
@@ -4,10 +4,7 @@ FROM quay.io/cybozu/ubuntu:18.04
 
 ARG MOCO_VERSION=0.1.1
 
-COPY workspace/bin/ /usr/local/mysql/bin/
-COPY workspace/lib/ /usr/local/mysql/lib/
-COPY workspace/share/ /usr/local/mysql/share/
-COPY workspace/LICENSE /usr/local/mysql/LICENSE
+COPY workspace /usr/local/mysql/
 COPY ping.sh /ping.sh
 
 RUN apt-get update \


### PR DESCRIPTION
These can be combined into one.

```console
$ mkdir -p workspace/bin
$ touch workspace/bin/aaa
$ touch workspace/LICENSE
$ cat > Dockerfile <<EOF
FROM scratch

COPY workspace /usr/local/mysql/
EOF

$ docker build . -t hoge
$ docker image save hoge | tar xf - 6e37a696520cf4876ef2d1eb6a6598ffc4456c652ca00183edcee7a73515cd7f/layer.tar
$ tar tf 6e37a696520cf4876ef2d1eb6a6598ffc4456c652ca00183edcee7a73515cd7f/layer.tar
usr/
usr/local/
usr/local/mysql/
usr/local/mysql/LICENSE
usr/local/mysql/bin/
usr/local/mysql/bin/aaa
```