### PR TITLE
ci: omit validation with hadolint.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,12 +75,6 @@ jobs:
             if [ -e "$dir/NO_TAG_BRANCH_CONSISTENCY" ]; then exit 0; fi
             ./tag_branch_consistency $dir
       - run:
-          name: Lint Dockerfile
-          command: |
-            dir=<< parameters.dir >>
-            if [ "$dir" = "" ]; then dir=<< parameters.container-image >> ; fi
-            docker run --rm -i hadolint/hadolint /bin/hadolint - --ignore DL3008 --ignore DL3016 < $dir/Dockerfile
-      - run:
           name: Build images
           no_output_timeout: 20m
           command: |

--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -28,7 +28,6 @@ COPY --from=build /work/prometheus /usr/local/prometheus/bin/prometheus
 COPY --from=build /work/LICENSE /usr/local/prometheus/LICENSE
 COPY --from=build /work/console_libraries /usr/share/prometheus/console_libraries
 COPY --from=build /work/consoles /usr/share/prometheus/consoles
-# hadolint ignore=DL3010
 COPY --from=build /work/npm_licenses.tar.bz2 /usr/local/prometheus/npm_licenses.tar.bz2
 
 RUN mkdir -m 755 /data && chown 10000:10000 /data


### PR DESCRIPTION
This PR drops validation of Dockerfiles with hadolint from the CI steps.
This is because hadolint tends to report trivial or false-positive "errors."

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>