### PR TITLE
[neco-admission] mutate ephemeral-storage limit and request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .*.swp
 /.vscode
 cover.out
+vendor
+/.idea

--- a/admission/README.md
+++ b/admission/README.md
@@ -77,10 +77,11 @@ if the resource is annotated with `admission.cybozu.com/prevent: delete`.
 PodMutator
 ----------
 
-PodMutator mutates Pod manifests to mount writable emptyDir to `/tmp` for each containers.
-The purpose of this mutator is to prevent Pods from unexpected death by writing to read-only filesystem. 
+PodMutator mutates Pod manifests to specify local ephemeral storage limit to 1GiB and request to 200MiB for each container.
+The purpose of this mutator is to prevent Pods from overuse of local ephemeral storage.
 
-However, Pods that already have another volumes mounted under `/tmp/*` are excluded from the mutating target.
+If you want to use more ephemeral storage than the limit, you can use generic ephemeral volume instead of
+local ephemeral storage.
 
 PodValidator
 ------------

--- a/admission/hooks/mutate_pod.go
+++ b/admission/hooks/mutate_pod.go
@@ -2,20 +2,22 @@ package hooks
 
 import (
 	"context"
-	"crypto/sha1"
-	"encoding/hex"
 	"encoding/json"
 	"net/http"
-	"strconv"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // +kubebuilder:webhook:path=/mutate-pod,mutating=true,failurePolicy=fail,sideEffects=None,groups="",resources=pods,verbs=create,versions=v1,name=mpod.kb.io,admissionReviewVersions={v1,v1beta1}
+
+var (
+	ephemeralStorageRequest = resource.MustParse("200Mi")
+	ephemeralStorageLimit   = resource.MustParse("1Gi")
+)
 
 type podMutator struct {
 	client  client.Client
@@ -36,20 +38,24 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 
 	poPatched := po.DeepCopy()
 	for i, co := range po.Spec.Containers {
-		if !m.isMountedTmp(&co) {
-			volumeName := m.generateVolumeName(co.Name, po.Spec.Volumes)
-			m.appendEmptyDir(volumeName, poPatched)
-			poPatched.Spec.Containers[i].VolumeMounts = append(poPatched.Spec.Containers[i].VolumeMounts,
-				corev1.VolumeMount{Name: volumeName, MountPath: "/tmp"})
+		if co.Resources.Requests == nil {
+			poPatched.Spec.Containers[i].Resources.Requests = corev1.ResourceList{}
 		}
+		poPatched.Spec.Containers[i].Resources.Requests[corev1.ResourceEphemeralStorage] = ephemeralStorageRequest
+		if co.Resources.Limits == nil {
+			poPatched.Spec.Containers[i].Resources.Limits = corev1.ResourceList{}
+		}
+		poPatched.Spec.Containers[i].Resources.Limits[corev1.ResourceEphemeralStorage] = ephemeralStorageLimit
 	}
 	for i, co := range po.Spec.InitContainers {
-		if !m.isMountedTmp(&co) {
-			volumeName := m.generateVolumeName(co.Name, po.Spec.Volumes)
-			m.appendEmptyDir(volumeName, poPatched)
-			poPatched.Spec.InitContainers[i].VolumeMounts = append(poPatched.Spec.InitContainers[i].VolumeMounts,
-				corev1.VolumeMount{Name: volumeName, MountPath: "/tmp"})
+		if co.Resources.Requests == nil {
+			poPatched.Spec.InitContainers[i].Resources.Requests = corev1.ResourceList{}
 		}
+		poPatched.Spec.InitContainers[i].Resources.Requests[corev1.ResourceEphemeralStorage] = ephemeralStorageRequest
+		if co.Resources.Limits == nil {
+			poPatched.Spec.InitContainers[i].Resources.Limits = corev1.ResourceList{}
+		}
+		poPatched.Spec.InitContainers[i].Resources.Limits[corev1.ResourceEphemeralStorage] = ephemeralStorageLimit
 	}
 
 	marshaled, err := json.Marshal(poPatched)
@@ -57,43 +63,4 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaled)
-}
-
-func (m *podMutator) isMountedTmp(co *corev1.Container) bool {
-	for _, mount := range co.VolumeMounts {
-		if mount.MountPath == "/tmp" || strings.HasPrefix(mount.MountPath, "/tmp/") {
-			return true
-		}
-	}
-	return false
-}
-
-func (m *podMutator) hashString(name string) string {
-	sum := sha1.Sum([]byte(name))
-	return hex.EncodeToString(sum[:])
-}
-
-func (m *podMutator) isUniqueVolumeName(volumes []corev1.Volume, name string) bool {
-	for _, v := range volumes {
-		if v.Name == name {
-			return false
-		}
-	}
-	return true
-}
-
-func (m *podMutator) generateVolumeName(containerName string, volumes []corev1.Volume) string {
-	for i := 0; ; i++ {
-		volumeName := "tmp-" + m.hashString(containerName+strconv.Itoa(i))
-		if m.isUniqueVolumeName(volumes, volumeName) {
-			return volumeName
-		}
-	}
-}
-
-func (m *podMutator) appendEmptyDir(volumeName string, po *corev1.Pod) {
-	po.Spec.Volumes = append(po.Spec.Volumes, corev1.Volume{
-		Name:         volumeName,
-		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
-	})
 }

--- a/admission/hooks/mutate_pod_test.go
+++ b/admission/hooks/mutate_pod_test.go
@@ -2,11 +2,11 @@ package hooks
 
 import (
 	"strings"
-	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
@@ -22,7 +22,7 @@ func createPod(po *v1.Pod) *v1.Pod {
 }
 
 var _ = Describe("mutate Pod webhook", func() {
-	It("should append volumeMount to container", func() {
+	It("should specify ephemeral-storage request and limit to container", func() {
 		podManifest := `apiVersion: v1
 kind: Pod
 metadata:
@@ -40,13 +40,13 @@ spec:
 		Expect(err).NotTo(HaveOccurred())
 
 		out := createPod(po)
-		Expect(out.Spec.Volumes).Should(HaveLen(1))
-		Expect(out.Spec.Volumes[0].VolumeSource).Should(Equal(v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}))
-		Expect(out.Spec.Containers[0].VolumeMounts).Should(HaveLen(1))
-		Expect(out.Spec.Containers[0].VolumeMounts[0].MountPath).Should(Equal("/tmp"))
+		Expect(out.Spec.Containers[0].Resources.Requests).Should(HaveKey(v1.ResourceEphemeralStorage))
+		Expect(out.Spec.Containers[0].Resources.Limits).Should(HaveKey(v1.ResourceEphemeralStorage))
+		Expect(out.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("200Mi")))
+		Expect(out.Spec.Containers[0].Resources.Limits[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("1Gi")))
 	})
 
-	It("should append volumeMount to initContainer", func() {
+	It("should specify ephemeral-storage request and limit to initContainer", func() {
 		podManifest := `apiVersion: v1
 kind: Pod
 metadata:
@@ -68,16 +68,17 @@ spec:
 		Expect(err).NotTo(HaveOccurred())
 
 		out := createPod(po)
-		Expect(out.Spec.Volumes).Should(HaveLen(2))
-		Expect(out.Spec.Volumes[0].VolumeSource).Should(Equal(v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}))
-		Expect(out.Spec.Volumes[1].VolumeSource).Should(Equal(v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}))
-		Expect(out.Spec.Containers[0].VolumeMounts).Should(HaveLen(1))
-		Expect(out.Spec.Containers[0].VolumeMounts[0].MountPath).Should(Equal("/tmp"))
-		Expect(out.Spec.InitContainers[0].VolumeMounts).Should(HaveLen(1))
-		Expect(out.Spec.InitContainers[0].VolumeMounts[0].MountPath).Should(Equal("/tmp"))
+		Expect(out.Spec.Containers[0].Resources.Requests).Should(HaveKey(v1.ResourceEphemeralStorage))
+		Expect(out.Spec.Containers[0].Resources.Limits).Should(HaveKey(v1.ResourceEphemeralStorage))
+		Expect(out.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("200Mi")))
+		Expect(out.Spec.Containers[0].Resources.Limits[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("1Gi")))
+		Expect(out.Spec.InitContainers[0].Resources.Requests).Should(HaveKey(v1.ResourceEphemeralStorage))
+		Expect(out.Spec.InitContainers[0].Resources.Limits).Should(HaveKey(v1.ResourceEphemeralStorage))
+		Expect(out.Spec.InitContainers[0].Resources.Requests[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("200Mi")))
+		Expect(out.Spec.InitContainers[0].Resources.Limits[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("1Gi")))
 	})
 
-	It("should not append volumeMount to containers", func() {
+	It("should overwrite ephemeral-storage request and limit to containers", func() {
 		podManifest := `apiVersion: v1
 kind: Pod
 metadata:
@@ -88,21 +89,20 @@ spec:
  - name: ubuntu
    image: quay.io/cybozu/ubuntu
    command: ["pause"]
-   volumeMounts:
-   - name: vol1
-     mountPath: /tmp/hoge
+   resources:
+     requests:
+       ephemeral-storage: "1Gi"
+     limits:
+       ephemeral-storage: "2Gi"
  initContainers:
  - name: init
    image: quay.io/cybozu/ubuntu
    command: ["pause"]
-   volumeMounts:
-   - name: vol2
-     mountPath: /tmp
- volumes:
- - name: vol1
-   emptyDir: {}
- - name: vol2
-   emptyDir: {}
+   resources:
+     requests:
+       ephemeral-storage: "100Mi"
+     limits:
+       ephemeral-storage: "100Mi"
 `
 		d := yaml.NewYAMLOrJSONDecoder(strings.NewReader(podManifest), 4096)
 		po := &v1.Pod{}
@@ -110,54 +110,13 @@ spec:
 		Expect(err).NotTo(HaveOccurred())
 
 		out := createPod(po)
-		Expect(out.Spec.Volumes).Should(HaveLen(2))
-		Expect(out.Spec.Volumes[0].VolumeSource).Should(Equal(v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}))
-		Expect(out.Spec.Volumes[1].VolumeSource).Should(Equal(v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}))
-		Expect(out.Spec.Containers[0].VolumeMounts).Should(HaveLen(1))
-		Expect(out.Spec.Containers[0].VolumeMounts[0].MountPath).Should(Equal("/tmp/hoge"))
-		Expect(out.Spec.InitContainers[0].VolumeMounts).Should(HaveLen(1))
-		Expect(out.Spec.InitContainers[0].VolumeMounts[0].MountPath).Should(Equal("/tmp"))
+		Expect(out.Spec.Containers[0].Resources.Requests).Should(HaveKey(v1.ResourceEphemeralStorage))
+		Expect(out.Spec.Containers[0].Resources.Limits).Should(HaveKey(v1.ResourceEphemeralStorage))
+		Expect(out.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("200Mi")))
+		Expect(out.Spec.Containers[0].Resources.Limits[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("1Gi")))
+		Expect(out.Spec.InitContainers[0].Resources.Requests).Should(HaveKey(v1.ResourceEphemeralStorage))
+		Expect(out.Spec.InitContainers[0].Resources.Limits).Should(HaveKey(v1.ResourceEphemeralStorage))
+		Expect(out.Spec.InitContainers[0].Resources.Requests[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("200Mi")))
+		Expect(out.Spec.InitContainers[0].Resources.Limits[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("1Gi")))
 	})
 })
-
-func TestPodMutatorIsMountedTmp(t *testing.T) {
-	tests := []struct {
-		name      string
-		container *v1.Container
-		want      bool
-	}{
-		{
-			name:      "empty volumeMounts",
-			container: &v1.Container{VolumeMounts: []v1.VolumeMount{}},
-			want:      false,
-		},
-		{
-			name:      "/tmp",
-			container: &v1.Container{VolumeMounts: []v1.VolumeMount{{MountPath: "/tmp"}}},
-			want:      true,
-		},
-		{
-			name:      "/tmp/hoge",
-			container: &v1.Container{VolumeMounts: []v1.VolumeMount{{MountPath: "/tmp/hoge"}}},
-			want:      true,
-		},
-		{
-			name:      "/tmp1",
-			container: &v1.Container{VolumeMounts: []v1.VolumeMount{{MountPath: "/tmp1"}}},
-			want:      false,
-		},
-		{
-			name:      "/hoge, /piyo, /tmp",
-			container: &v1.Container{VolumeMounts: []v1.VolumeMount{{MountPath: "/hoge"}, {MountPath: "/piyo"}, {MountPath: "/tmp"}}},
-			want:      true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			m := &podMutator{}
-			if got := m.isMountedTmp(tt.container); got != tt.want {
-				t.Errorf("podMutator.isMountedTmp() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}


### PR DESCRIPTION
Replacing PSP with PSA causes `ReadOnlyRootFilesystem: false`.
As a result, there is no need to mount `/tmp` anymore.
Instead, we have to limit the size of local ephemeral storages.

Signed-off-by: zoetrope <a.ikezoe@gmail.com>