### PR TITLE
neco-admission: add repositoryPrefix to ArgoCDApplicationValidator

### DIFF
--- a/admission/docs/configuration.md
+++ b/admission/docs/configuration.md
@@ -16,10 +16,11 @@ The configuration of `ArgoCDApplicationValidator` is a map with the following ke
 Each rule represents the restriction on the applications in a certain repository.  
 If neco-admission has no rule for a given App's repoURL, neco-admission denies the API request.
 
-| Name       | Type       | Description                                                               |
-| ---------- | ---------- | ------------------------------------------------------------------------- |
-| repository | string     | A URL of the repository to be matched with `applications.spec.source.repoURL`.                                                   |
-| projects   | \[\]string | A list of `applications.spec.project`s allowed for the applications in the repository. |
+| Name             | Type       | Description                                                                             |
+| ---------------- | ---------- | --------------------------------------------------------------------------------------- |
+| repository       | string     | A URL of the repository to be matched with `applications.spec.source.repoURL`.          |
+| repositoryPrefix | string     | A URL prefix of the repositories to be matched with `applications.spec.source.repoURL`. |
+| projects         | \[\]string | A list of `applications.spec.project`s allowed for the applications in the repository.  |
 
 ### `.git` suffix in `repository`
 

--- a/admission/hooks/config.go
+++ b/admission/hooks/config.go
@@ -12,6 +12,7 @@ type ArgoCDApplicationValidatorConfig struct {
 
 // ArgoCDApplicationRule is a rule for applications
 type ArgoCDApplicationRule struct {
-	Repository string   `json:"repository"`
-	Projects   []string `json:"projects"`
+	Repository       string   `json:"repository"`
+	RepositoryPrefix string   `json:"repositoryPrefix"`
+	Projects         []string `json:"projects"`
 }

--- a/admission/hooks/validate_application.go
+++ b/admission/hooks/validate_application.go
@@ -60,12 +60,16 @@ func (v *argocdApplicationValidator) Handle(ctx context.Context, req admission.R
 }
 
 func (v *argocdApplicationValidator) findProjects(repo string) []string {
+	var projects []string
 	for _, r := range v.config.Rules {
 		if v.ignoreGitSuffix(r.Repository) == v.ignoreGitSuffix(repo) {
-			return r.Projects
+			projects = append(projects, r.Projects...)
+		}
+		if r.RepositoryPrefix != "" && strings.HasPrefix(repo, r.RepositoryPrefix) {
+			projects = append(projects, r.Projects...)
 		}
 	}
-	return nil
+	return projects
 }
 
 func (v *argocdApplicationValidator) ignoreGitSuffix(s string) string {


### PR DESCRIPTION
This PR adds `repositoryPrefix` field to the ArgoCDApplicationValidator.
`repository` field is kept for maintenance; it will be removed soon.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>