### PR TITLE
Revert "[neco-admission] mutate ephemeral-storage limit and request"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@
 .*.swp
 /.vscode
 cover.out
-vendor
-/.idea

--- a/admission/README.md
+++ b/admission/README.md
@@ -77,11 +77,10 @@ if the resource is annotated with `admission.cybozu.com/prevent: delete`.
 PodMutator
 ----------
 
-PodMutator mutates Pod manifests to specify local ephemeral storage limit to 1GiB and request to 200MiB for each container.
-The purpose of this mutator is to prevent Pods from overuse of local ephemeral storage.
+PodMutator mutates Pod manifests to mount writable emptyDir to `/tmp` for each containers.
+The purpose of this mutator is to prevent Pods from unexpected death by writing to read-only filesystem. 
 
-If you want to use more ephemeral storage than the limit, you can use generic ephemeral volume instead of
-local ephemeral storage.
+However, Pods that already have another volumes mounted under `/tmp/*` are excluded from the mutating target.
 
 PodValidator
 ------------

--- a/admission/hooks/mutate_pod.go
+++ b/admission/hooks/mutate_pod.go
@@ -2,22 +2,20 @@ package hooks
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // +kubebuilder:webhook:path=/mutate-pod,mutating=true,failurePolicy=fail,sideEffects=None,groups="",resources=pods,verbs=create,versions=v1,name=mpod.kb.io,admissionReviewVersions={v1,v1beta1}
-
-var (
-	ephemeralStorageRequest = resource.MustParse("200Mi")
-	ephemeralStorageLimit   = resource.MustParse("1Gi")
-)
 
 type podMutator struct {
 	client  client.Client
@@ -38,24 +36,20 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 
 	poPatched := po.DeepCopy()
 	for i, co := range po.Spec.Containers {
-		if co.Resources.Requests == nil {
-			poPatched.Spec.Containers[i].Resources.Requests = corev1.ResourceList{}
+		if !m.isMountedTmp(&co) {
+			volumeName := m.generateVolumeName(co.Name, po.Spec.Volumes)
+			m.appendEmptyDir(volumeName, poPatched)
+			poPatched.Spec.Containers[i].VolumeMounts = append(poPatched.Spec.Containers[i].VolumeMounts,
+				corev1.VolumeMount{Name: volumeName, MountPath: "/tmp"})
 		}
-		poPatched.Spec.Containers[i].Resources.Requests[corev1.ResourceEphemeralStorage] = ephemeralStorageRequest
-		if co.Resources.Limits == nil {
-			poPatched.Spec.Containers[i].Resources.Limits = corev1.ResourceList{}
-		}
-		poPatched.Spec.Containers[i].Resources.Limits[corev1.ResourceEphemeralStorage] = ephemeralStorageLimit
 	}
 	for i, co := range po.Spec.InitContainers {
-		if co.Resources.Requests == nil {
-			poPatched.Spec.InitContainers[i].Resources.Requests = corev1.ResourceList{}
+		if !m.isMountedTmp(&co) {
+			volumeName := m.generateVolumeName(co.Name, po.Spec.Volumes)
+			m.appendEmptyDir(volumeName, poPatched)
+			poPatched.Spec.InitContainers[i].VolumeMounts = append(poPatched.Spec.InitContainers[i].VolumeMounts,
+				corev1.VolumeMount{Name: volumeName, MountPath: "/tmp"})
 		}
-		poPatched.Spec.InitContainers[i].Resources.Requests[corev1.ResourceEphemeralStorage] = ephemeralStorageRequest
-		if co.Resources.Limits == nil {
-			poPatched.Spec.InitContainers[i].Resources.Limits = corev1.ResourceList{}
-		}
-		poPatched.Spec.InitContainers[i].Resources.Limits[corev1.ResourceEphemeralStorage] = ephemeralStorageLimit
 	}
 
 	marshaled, err := json.Marshal(poPatched)
@@ -63,4 +57,43 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaled)
+}
+
+func (m *podMutator) isMountedTmp(co *corev1.Container) bool {
+	for _, mount := range co.VolumeMounts {
+		if mount.MountPath == "/tmp" || strings.HasPrefix(mount.MountPath, "/tmp/") {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *podMutator) hashString(name string) string {
+	sum := sha1.Sum([]byte(name))
+	return hex.EncodeToString(sum[:])
+}
+
+func (m *podMutator) isUniqueVolumeName(volumes []corev1.Volume, name string) bool {
+	for _, v := range volumes {
+		if v.Name == name {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *podMutator) generateVolumeName(containerName string, volumes []corev1.Volume) string {
+	for i := 0; ; i++ {
+		volumeName := "tmp-" + m.hashString(containerName+strconv.Itoa(i))
+		if m.isUniqueVolumeName(volumes, volumeName) {
+			return volumeName
+		}
+	}
+}
+
+func (m *podMutator) appendEmptyDir(volumeName string, po *corev1.Pod) {
+	po.Spec.Volumes = append(po.Spec.Volumes, corev1.Volume{
+		Name:         volumeName,
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	})
 }


### PR DESCRIPTION
This reverts commit fc56ace5b815c16340b4d776d23ca7d272971531.

Unless /var/log and /var/lib/kubelet are in the same filesystem, we can't specify the limit for local ephemeral storage
https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#configurations-for-local-ephemeral-storage