### PR TITLE
separate validation webhooks to files

### DIFF
--- a/admission/hooks/validate_deployment_replica_count.go
+++ b/admission/hooks/validate_deployment_replica_count.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -47,41 +46,6 @@ func (v *deploymentReplicaCountValidator) Handle(ctx context.Context, req admiss
 	}
 
 	if *deploy.Spec.Replicas != 0 {
-		return admission.Denied("replicas must be 0")
-	}
-
-	return admission.Allowed("ok")
-}
-
-// +kubebuilder:webhook:path=/validate-scale-deployment-replica-count,mutating=false,failurePolicy=fail,sideEffects=None,groups="apps",resources=deployments/scale,verbs=update,versions=v1,name=vscaledeploymentreplicacount.kb.io,admissionReviewVersions={v1,v1beta1}
-
-type deploymentReplicaCountScaleValidator struct {
-	client  client.Client
-	decoder *admission.Decoder
-}
-
-func NewDeploymentReplicaCountScaleValidator(c client.Client, decoder *admission.Decoder) http.Handler {
-	return &webhook.Admission{Handler: &deploymentReplicaCountScaleValidator{client: c, decoder: decoder}}
-}
-
-func (v *deploymentReplicaCountScaleValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
-	scale := &autoscalingv1.Scale{}
-	err := v.decoder.Decode(req, scale)
-	if err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
-	}
-
-	deploy := &appsv1.Deployment{}
-	err = v.client.Get(ctx, client.ObjectKey{Namespace: scale.GetNamespace(), Name: scale.GetName()}, deploy)
-	if err != nil {
-		return admission.Errored(http.StatusInternalServerError, err)
-	}
-
-	if !isForceReplicaCountTargetDeployment(deploy) {
-		return admission.Allowed("not a target")
-	}
-
-	if scale.Spec.Replicas != 0 {
 		return admission.Denied("replicas must be 0")
 	}
 

--- a/admission/hooks/validate_deployment_replica_count_scale.go
+++ b/admission/hooks/validate_deployment_replica_count_scale.go
@@ -1,0 +1,47 @@
+package hooks
+
+import (
+	"context"
+	"net/http"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// +kubebuilder:webhook:path=/validate-scale-deployment-replica-count,mutating=false,failurePolicy=fail,sideEffects=None,groups="apps",resources=deployments/scale,verbs=update,versions=v1,name=vscaledeploymentreplicacount.kb.io,admissionReviewVersions={v1,v1beta1}
+
+type deploymentReplicaCountScaleValidator struct {
+	client  client.Client
+	decoder *admission.Decoder
+}
+
+func NewDeploymentReplicaCountScaleValidator(c client.Client, decoder *admission.Decoder) http.Handler {
+	return &webhook.Admission{Handler: &deploymentReplicaCountScaleValidator{client: c, decoder: decoder}}
+}
+
+func (v *deploymentReplicaCountScaleValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	scale := &autoscalingv1.Scale{}
+	err := v.decoder.Decode(req, scale)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	deploy := &appsv1.Deployment{}
+	err = v.client.Get(ctx, client.ObjectKey{Namespace: scale.GetNamespace(), Name: scale.GetName()}, deploy)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	if !isForceReplicaCountTargetDeployment(deploy) {
+		return admission.Allowed("not a target")
+	}
+
+	if scale.Spec.Replicas != 0 {
+		return admission.Denied("replicas must be 0")
+	}
+
+	return admission.Allowed("ok")
+}

--- a/admission/hooks/validate_deployment_replica_count_scale_test.go
+++ b/admission/hooks/validate_deployment_replica_count_scale_test.go
@@ -1,0 +1,84 @@
+package hooks
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	autoscalingv1 "k8s.io/client-go/applyconfigurations/autoscaling/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var _ = Describe("validate deployment replica count scale webhook", func() {
+	testcases := []struct {
+		scenario          string
+		hasAnnotation     bool
+		forceReplicaCount int
+		expectScalable    bool
+	}{
+		{
+			scenario:          "should deny to scale a Deployment to replicas = 1",
+			hasAnnotation:     true,
+			forceReplicaCount: 0,
+			expectScalable:    false,
+		},
+		{
+			scenario:       "should allow to scale a Deployment without force-replica-count annotation",
+			hasAnnotation:  false,
+			expectScalable: true,
+		},
+		{
+			scenario:          "should allow to scale a Deployment with annotation force-replica-count != 0 and force-replica-count != replicas",
+			hasAnnotation:     true,
+			forceReplicaCount: 2,
+			expectScalable:    true,
+		},
+		{
+			scenario:          "should allow to scale a Deployment with annotation force-replica-count != 0 and force-replica-count == replicas",
+			hasAnnotation:     true,
+			forceReplicaCount: 1,
+			expectScalable:    true,
+		},
+	}
+
+	for i, tt := range testcases {
+		manifestName := fmt.Sprintf("test-scale-deployment-%d", i)
+		tt := tt
+
+		It(tt.scenario, func() {
+			var deployManifest string
+			if tt.hasAnnotation {
+				deployManifest = fmt.Sprintf(deployManifestWithAnnotationTemplate, manifestName, tt.forceReplicaCount, 0)
+			} else {
+				deployManifest = fmt.Sprintf(deployManifestWithoutAnnotationTemplate, manifestName, 0)
+			}
+
+			d := yaml.NewYAMLOrJSONDecoder(strings.NewReader(deployManifest), 4096)
+			deploy := &appsv1.Deployment{}
+			err := d.Decode(deploy)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Create(testCtx, deploy)
+			Expect(err).NotTo(HaveOccurred())
+
+			k8s, err := kubernetes.NewForConfig(k8sConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			deployClient := k8s.AppsV1().Deployments("default")
+			scale := autoscalingv1.Scale().WithSpec(autoscalingv1.ScaleSpec().WithReplicas(1))
+
+			_, err = deployClient.ApplyScale(testCtx, manifestName, scale, metav1.ApplyOptions{FieldManager: "dummy", Force: true})
+
+			if tt.expectScalable {
+				Expect(err).NotTo(HaveOccurred())
+			} else {
+				Expect(err).To(HaveOccurred())
+			}
+
+		})
+	}
+})

--- a/admission/hooks/validate_deployment_replica_count_test.go
+++ b/admission/hooks/validate_deployment_replica_count_test.go
@@ -7,10 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	autoscalingv1 "k8s.io/client-go/applyconfigurations/autoscaling/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 const deployManifestWithoutAnnotationTemplate = `apiVersion: apps/v1
@@ -126,76 +123,6 @@ var _ = Describe("validate deployment replica count webhook", func() {
 			} else {
 				Expect(err).To(HaveOccurred())
 			}
-		})
-	}
-})
-
-var _ = Describe("validate deployment replica count scale webhook", func() {
-	testcases := []struct {
-		scenario          string
-		hasAnnotation     bool
-		forceReplicaCount int
-		expectScalable    bool
-	}{
-		{
-			scenario:          "should deny to scale a Deployment to replicas = 1",
-			hasAnnotation:     true,
-			forceReplicaCount: 0,
-			expectScalable:    false,
-		},
-		{
-			scenario:       "should allow to scale a Deployment without force-replica-count annotation",
-			hasAnnotation:  false,
-			expectScalable: true,
-		},
-		{
-			scenario:          "should allow to scale a Deployment with annotation force-replica-count != 0 and force-replica-count != replicas",
-			hasAnnotation:     true,
-			forceReplicaCount: 2,
-			expectScalable:    true,
-		},
-		{
-			scenario:          "should allow to scale a Deployment with annotation force-replica-count != 0 and force-replica-count == replicas",
-			hasAnnotation:     true,
-			forceReplicaCount: 1,
-			expectScalable:    true,
-		},
-	}
-
-	for i, tt := range testcases {
-		manifestName := fmt.Sprintf("test-scale-deployment-%d", i)
-		tt := tt
-
-		It(tt.scenario, func() {
-			var deployManifest string
-			if tt.hasAnnotation {
-				deployManifest = fmt.Sprintf(deployManifestWithAnnotationTemplate, manifestName, tt.forceReplicaCount, 0)
-			} else {
-				deployManifest = fmt.Sprintf(deployManifestWithoutAnnotationTemplate, manifestName, 0)
-			}
-
-			d := yaml.NewYAMLOrJSONDecoder(strings.NewReader(deployManifest), 4096)
-			deploy := &appsv1.Deployment{}
-			err := d.Decode(deploy)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = k8sClient.Create(testCtx, deploy)
-			Expect(err).NotTo(HaveOccurred())
-
-			k8s, err := kubernetes.NewForConfig(k8sConfig)
-			Expect(err).NotTo(HaveOccurred())
-
-			deployClient := k8s.AppsV1().Deployments("default")
-			scale := autoscalingv1.Scale().WithSpec(autoscalingv1.ScaleSpec().WithReplicas(1))
-
-			_, err = deployClient.ApplyScale(testCtx, manifestName, scale, metav1.ApplyOptions{FieldManager: "dummy", Force: true})
-
-			if tt.expectScalable {
-				Expect(err).NotTo(HaveOccurred())
-			} else {
-				Expect(err).To(HaveOccurred())
-			}
-
 		})
 	}
 })


### PR DESCRIPTION
I splited `admission/hooks/validate_deployment_replica_count.go` and `admission/hooks/validate_deployment_replica_count_test.go` in two files each to avoid generating differences in CI.

Signed-off-by: terasihma <tomoya-terashima@cybozu.co.jp>