### PR TITLE
unbound: add a root trust anchor for DNSSEC validation

### DIFF
--- a/unbound/Dockerfile
+++ b/unbound/Dockerfile
@@ -15,6 +15,12 @@ RUN mkdir -p /usr/local/unbound \
     && make install \
     && mv LICENSE /usr/local/unbound/LICENSE
 
+# It fails on the first time by design.
+# To see it works as intended, we run the command twice and check the second exit code.
+# See: https://unbound.docs.nlnetlabs.nl/en/latest/manpages/unbound-anchor.html#exit-code
+RUN /usr/local/unbound/sbin/unbound-anchor -v || true
+RUN /usr/local/unbound/sbin/unbound-anchor -v
+
 FROM quay.io/cybozu/ubuntu:22.04
 
 RUN apt-get update \
@@ -23,6 +29,7 @@ RUN apt-get update \
 COPY reload-unbound /usr/local/bin/reload-unbound
 COPY --from=build /usr/local/unbound/LICENSE /usr/local/unbound/LICENSE
 COPY --from=build /usr/local/unbound/sbin /usr/local/unbound/sbin
+COPY --from=build /usr/local/unbound/etc/unbound/root.key /usr/local/unbound/etc/unbound/root.key
 
 ENV PATH=/usr/local/unbound/sbin:/usr/local/bin:"$PATH"
 EXPOSE 53 53/udp


### PR DESCRIPTION
Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>