### PR TITLE
Stop scanning unbound images on quay

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -998,7 +998,6 @@ workflows:
       - build:
           name: build-unbound
           container-image: unbound
-          scan: true
       - build:
           name: build-unbound_exporter
           container-image: unbound_exporter


### PR DESCRIPTION
Stop scanning unbound images on quay, because the one on ghcr is already scanned. 
https://github.com/cybozu/neco-containers/blob/9b2ccb71c3b88eebb1d0325da8e9a1bef2624c94/.github/workflows/main.yaml#L54-L56

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>