### PR TITLE
Rename scan flag name

### DIFF
--- a/.github/actions/build_push/action.yaml
+++ b/.github/actions/build_push/action.yaml
@@ -23,8 +23,8 @@ inputs:
     description: "Run make test before building docker image"
     required: false
     default: "false"
-  scan:
-    description: "Enable image scanning (true, false, or auto)"
+  request-scan:
+    description: "Request image scanning (true, false, or auto)"
     required: false
     default: "auto"
   target:
@@ -44,7 +44,7 @@ runs:
         dir: ${{ inputs.dir }}
         container-image: ${{ inputs.container-image }}
         target: ${{ inputs.target }}
-        scan: ${{ inputs.scan }}
+        request-scan: ${{ inputs.request-scan }}
         github_token: ${{ inputs.github_token }}
     - name: Set container build platform
       if: ${{ steps.extract.outputs.build }}

--- a/.github/actions/extract_tags/action.yaml
+++ b/.github/actions/extract_tags/action.yaml
@@ -12,8 +12,8 @@ inputs:
     description: "target name"
     required: false
     default: ""
-  scan:
-    description: "Enable image scanning (true, false, or auto)"
+  request-scan:
+    description: "Request image scanning (true, false, or auto)"
     required: false
     default: "auto"
   github_token:
@@ -98,20 +98,20 @@ runs:
       working-directory: ${{ steps.dir.outputs.dir }}
       run: |
         # Check if scan-mode is manually overridden
-        echo "inputs.scan is: ${{ inputs.scan }}"
-        if [ -z "${{ inputs.scan }}" ]; then
+        echo "inputs.request-scan is: ${{ inputs.request-scan }}"
+        if [ -z "${{ inputs.request-scan }}" ]; then
           echo "Calculating scanning mode..."
-        elif [ "${{ inputs.scan }}" = "auto" ]; then
+        elif [ "${{ inputs.request-scan }}" = "auto" ]; then
           echo "Calculating scanning mode..."
-        elif [ "${{ inputs.scan }}" = "true" ]; then
+        elif [ "${{ inputs.request-scan }}" = "true" ]; then
           echo "Scanning is enabled manually."
           echo "scan=true" >> $GITHUB_OUTPUT
           exit 0
-        elif [ "${{ inputs.scan }}" = "false" ]; then
+        elif [ "${{ inputs.request-scan }}" = "false" ]; then
           echo "Scanning is disabled manually."
           exit 0
         else
-          echo "inputs.scan has an invalid value"
+          echo "inputs.request-scan has an invalid value"
           exit 1
         fi
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,10 +32,10 @@ jobs:
             container-image: "chrony"
           - dir: "./cilium-certgen"
             container-image: "cilium-certgen"
-            scan: "false"
+            request-scan: "false"
           - dir: "./cilium-operator-generic"
             container-image: "cilium-operator-generic"
-            scan: "false"
+            request-scan: "false"
           - dir: "./configmap-reload"
             container-image: "configmap-reload"
           - dir: "./contour"
@@ -53,19 +53,19 @@ jobs:
           - dir: "./golang-all/golang-1.20-focal"
             container-image: "golang"
             enable_arm64: true
-            scan: "true"
+            request-scan: "true"
           - dir: "./golang-all/golang-1.20-jammy"
             container-image: "golang"
             enable_arm64: true
-            scan: "true"
+            request-scan: "true"
           - dir: "./golang-all/golang-1.21-focal"
             container-image: "golang"
             enable_arm64: true
-            scan: "true"
+            request-scan: "true"
           - dir: "./golang-all/golang-1.21-jammy"
             container-image: "golang"
             enable_arm64: true
-            scan: "true"
+            request-scan: "true"
           - dir: "./grafana-operator"
             container-image: "grafana-operator"
           - dir: "./haproxy"
@@ -103,14 +103,14 @@ jobs:
             container-image: "hubble"
           - dir: "./hubble-relay"
             container-image: "hubble-relay"
-            scan: "false"
+            request-scan: "false"
           - dir: "./hubble-ui"
             container-image: "hubble-ui-frontend"
-            scan: "false"
+            request-scan: "false"
             target: "frontend"
           - dir: "./hubble-ui"
             container-image: "hubble-ui-backend"
-            scan: "false"
+            request-scan: "false"
             target: "backend"
           - dir: "./pause"
             container-image: "pause"
@@ -211,7 +211,7 @@ jobs:
           container-image: ${{ matrix.job.container-image }}
           enable_arm64: ${{ matrix.job.enable_arm64 }}
           make_test: ${{ matrix.job.make_test }}
-          scan: ${{ matrix.job.scan }}
+          request-scan: ${{ matrix.job.request-scan }}
           target: ${{ matrix.job.target }}
 
   build_admission:


### PR DESCRIPTION
### Change Detail

Currently, there are two distinct flags having the same name (`scan`).
One is the input of the `extract_tags` stage, and the other is the output of that.
https://github.com/cybozu/neco-containers/blob/main/.github/actions/extract_tags/action.yaml

This PR changes the input-side name to `request-scan`, while keeping the output-side `scan`.

### Background: BTW, why two distinct scan flags are needed?

Basically, scan is needed when:
- the image is built,
- the image is uploaded, and
- the image is based on a non-scratch image.

This can be computed automatically ... except for some irregular cases.
Normally this happens when base image is substituted by a variable `$X`.
https://github.com/cybozu/neco-containers/blob/main/hubble-relay/Dockerfile#L28

In such cases, CI asks us to set scan requirement manually.
The flag name is currently named `scan`, but it is better to give it another name (`request-scan`).

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>