### PR TITLE
ceph: add a procedure to create a patched image from the specific version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+      - "ceph-v*"
 jobs:
   build_container:
     strategy:

--- a/maintenance.md
+++ b/maintenance.md
@@ -173,6 +173,16 @@ In Regular update, do the following as part of the update of each CRD-providing 
 
 ***NOTE:*** The rook image is based on the ceph image. So upgrade the [rook](#rook) image next.
 
+### Create a patched image from the specific version
+
+When you want to create a new image with patches to the specific version of Ceph,
+follow these steps.
+
+1. Create a branch with the name `ceph-vX.Y.Z` from the commit you want, and push it.
+   - You must follow the branch naming convention to activate the image build and push jobs.
+   - If the branch already exists, you can skip this step.
+2. Create a PR to the branch `ceph-vX.Y.Z`, and merge it.
+
 ## cephcsi
 
 ![CSA Update](./csa_update.svg)


### PR DESCRIPTION
I added a procedure to add a procedure to create a patched image from the specific version and updated the GitHub workflow `main` job.

I do not update CircleCI job settings because it would become tricky to check if the branch name's prefix matches `ceph-v*` pattern. Let me make it out of the scope. I believe it is sufficient for images with a patch to the specific version to be pushed only to ghcr.io.