### PR TITLE
Add tcp-keepalive metrics

### DIFF
--- a/tcp-keepalive/README.md
+++ b/tcp-keepalive/README.md
@@ -23,6 +23,16 @@ Flags:
   -l, --listen string   Listen address and port (default "127.0.0.1:8000")
 ```
 
+### Metrics
+
+```
+receive_total{role="server",result="error"}
+receive_total{role="server",result="success"}
+
+send_total{role="server",result="error"}
+send_total{role="server",result="success"}
+```
+
 Client
 -----
 
@@ -40,4 +50,23 @@ Flags:
   -r, --retry-interval duration   Connect retry interval (default 1s)
   -s, --server string             server address (default "127.0.0.1:8000")
   -t, --timeout duration          Deadline to receive a keepalive message (default 15s)
+```
+
+### Metrics
+
+```
+connection{role="client",state="closed"}
+connection{role="client",state="established"}
+connection{role="client",state="unestablished"}
+
+receive_total{role="client",result="error"}
+receive_total{role="client",result="success"}
+receive_total{role="client",result="timeout"}
+
+retry_count{role="client"}
+retry_total{role="client"}
+
+send_total{role="client",result="error"}
+send_total{role="client",result="success"}
+send_total{role="client",result="timeout"}
 ```

--- a/tcp-keepalive/cmd/client.go
+++ b/tcp-keepalive/cmd/client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/neco-containers/tcp-keepalive/internal/client"
+	"github.com/neco-containers/tcp-keepalive/internal/metrics"
 
 	"github.com/spf13/cobra"
 )
@@ -20,6 +21,7 @@ var clientCmd = &cobra.Command{
 }
 
 var clientCfg = &client.Config{}
+var clientMetricsCfg = &metrics.Config{}
 
 func init() {
 	rootCmd.AddCommand(clientCmd)
@@ -29,13 +31,15 @@ func init() {
 	clientCmd.Flags().IntVarP(&clientCfg.RetryNum, "retry", "y", 0, "Number of retries (-1 means infinite)")
 	clientCmd.Flags().DurationVarP(&clientCfg.SendInterval, "interval", "i", time.Second*5, "Interval to send a keepalive message")
 	clientCmd.Flags().StringVarP(&clientCfg.ServerAddr, "server", "s", "127.0.0.1:8000", "server address")
+	clientCmd.Flags().BoolVarP(&clientMetricsCfg.Export, "metrics", "m", true, "Enable metrics")
+	clientCmd.Flags().StringVarP(&clientMetricsCfg.AddrPort, "metrics-server", "a", "0.0.0.0:8080", "Metrics server address and port")
 }
 
 func runClient(cmd *cobra.Command, args []string) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	c, err := client.NewClient(clientCfg)
+	c, err := client.NewClient(clientCfg, clientMetricsCfg)
 	if err != nil {
 		log.Error("failed to create client", slog.Any("error", err))
 		return

--- a/tcp-keepalive/cmd/server.go
+++ b/tcp-keepalive/cmd/server.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"time"
 
+	"github.com/neco-containers/tcp-keepalive/internal/metrics"
 	"github.com/neco-containers/tcp-keepalive/internal/server"
 
 	"github.com/spf13/cobra"
@@ -20,18 +21,21 @@ var serverCmd = &cobra.Command{
 }
 
 var serverCfg = &server.Config{}
+var serverMetricsCfg = &metrics.Config{}
 
 func init() {
 	rootCmd.AddCommand(serverCmd)
 
 	serverCmd.Flags().StringVarP(&serverCfg.ListenAddr, "listen", "l", "127.0.0.1:8000", "Listen address and port")
+	serverCmd.Flags().BoolVarP(&serverMetricsCfg.Export, "metrics", "m", true, "Enable metrics")
+	serverCmd.Flags().StringVarP(&serverMetricsCfg.AddrPort, "metrics-server", "a", "0.0.0.0:8080", "Metrics server address and port")
 }
 
 func runServer(cmd *cobra.Command, args []string) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	s, err := server.NewServer(serverCfg)
+	s, err := server.NewServer(serverCfg, serverMetricsCfg)
 	if err != nil {
 		log.Error("failed to create server", slog.Any("error", err))
 		return

--- a/tcp-keepalive/go.mod
+++ b/tcp-keepalive/go.mod
@@ -2,9 +2,15 @@ module github.com/neco-containers/tcp-keepalive
 
 go 1.22.3
 
-require github.com/spf13/cobra v1.8.1
+require (
+	github.com/VictoriaMetrics/metrics v1.34.0
+	github.com/spf13/cobra v1.8.1
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/valyala/fastrand v1.1.0 // indirect
+	github.com/valyala/histogram v1.2.0 // indirect
+	golang.org/x/sys v0.15.0 // indirect
 )

--- a/tcp-keepalive/go.sum
+++ b/tcp-keepalive/go.sum
@@ -1,3 +1,5 @@
+github.com/VictoriaMetrics/metrics v1.34.0 h1:0i8k/gdOJdSoZB4Z9pikVnVQXfhcIvnG7M7h2WaQW2w=
+github.com/VictoriaMetrics/metrics v1.34.0/go.mod h1:r7hveu6xMdUACXvB8TYdAj8WEsKzWB0EkpJN+RDtOf8=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
@@ -6,5 +8,11 @@ github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/valyala/fastrand v1.1.0 h1:f+5HkLW4rsgzdNoleUOB69hyT9IlD2ZQh9GyDMfb5G8=
+github.com/valyala/fastrand v1.1.0/go.mod h1:HWqCzkrkg6QXT8V2EXWvXCoow7vLwOFN002oeRzjapQ=
+github.com/valyala/histogram v1.2.0 h1:wyYGAZZt3CpwUiIb9AU/Zbllg1llXyrtApRS815OLoQ=
+github.com/valyala/histogram v1.2.0/go.mod h1:Hb4kBwb4UxsaNbbbh+RRz8ZR6pdodR57tzWUS3BUzXY=
+golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tcp-keepalive/internal/client/metrics.go
+++ b/tcp-keepalive/internal/client/metrics.go
@@ -1,0 +1,66 @@
+package client
+
+import (
+	internalmetrics "github.com/neco-containers/tcp-keepalive/internal/metrics"
+
+	"github.com/VictoriaMetrics/metrics"
+)
+
+var (
+	retryTotal             *metrics.Counter
+	retryCount             *metrics.Counter
+	sendSuccessTotal       *metrics.Counter
+	sendErrorTotal         *metrics.Counter
+	sendTimeoutTotal       *metrics.Counter
+	receiveSuccessTotal    *metrics.Counter
+	receiveErrorTotal      *metrics.Counter
+	receiveTimeoutTotal    *metrics.Counter
+	connStateUnestablished *metrics.Counter
+	connStateEstablished   *metrics.Counter
+	connStateClosed        *metrics.Counter
+)
+
+func initMetrics() {
+	retryTotal = metrics.NewCounter(`retry_total{role="client"}`)
+	retryCount = metrics.NewCounter(`retry_count{role="client"}`)
+	sendSuccessTotal = metrics.NewCounter(`send_total{role="client",result="success"}`)
+	sendErrorTotal = metrics.NewCounter(`send_total{role="client",result="error"}`)
+	sendTimeoutTotal = metrics.NewCounter(`send_total{role="client",result="timeout"}`)
+	receiveSuccessTotal = metrics.NewCounter(`receive_total{role="client",result="success"}`)
+	receiveErrorTotal = metrics.NewCounter(`receive_total{role="client",result="error"}`)
+	receiveTimeoutTotal = metrics.NewCounter(`receive_total{role="client",result="timeout"}`)
+	connStateUnestablished = metrics.NewCounter(`connection{role="client",state="unestablished"}`)
+	connStateEstablished = metrics.NewCounter(`connection{role="client",state="established"}`)
+	connStateClosed = metrics.NewCounter(`connection{role="client",state="closed"}`)
+}
+
+type Metrics struct {
+	*internalmetrics.Metrics
+}
+
+func NewMetrics(cfg *internalmetrics.Config) (*Metrics, error) {
+	m, err := internalmetrics.NewMetrics(cfg)
+	if err != nil {
+		return nil, err
+	}
+	initMetrics()
+	return &Metrics{m}, nil
+}
+
+func (m *Metrics) setConnStateUnestablished() {
+	connStateUnestablished.Set(1)
+	connStateEstablished.Set(0)
+	connStateClosed.Set(0)
+}
+
+func (m *Metrics) setConnStateEstablished() {
+	connStateUnestablished.Set(0)
+	connStateEstablished.Set(1)
+	connStateClosed.Set(0)
+}
+
+func (m *Metrics) setConnStateClosed() {
+	connStateUnestablished.Set(0)
+	connStateEstablished.Set(0)
+	connStateClosed.Set(1)
+}

--- a/tcp-keepalive/internal/metrics/config.go
+++ b/tcp-keepalive/internal/metrics/config.go
@@ -1,0 +1,15 @@
+package metrics
+
+import "net/netip"
+
+type Config struct {
+	Export   bool
+	AddrPort string
+}
+
+func (c *Config) Validate() error {
+	if _, err := netip.ParseAddrPort(c.AddrPort); err != nil {
+		return err
+	}
+	return nil
+}

--- a/tcp-keepalive/internal/metrics/metrics.go
+++ b/tcp-keepalive/internal/metrics/metrics.go
@@ -1,0 +1,29 @@
+package metrics
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/VictoriaMetrics/metrics"
+)
+
+type Metrics struct {
+	*Config
+}
+
+func NewMetrics(cfg *Config) (*Metrics, error) {
+	if cfg == nil {
+		return nil, errors.New("metrics config is nil")
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &Metrics{cfg}, nil
+}
+
+func (m *Metrics) Serve() error {
+	http.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
+		metrics.WritePrometheus(w, false)
+	})
+	return http.ListenAndServe(m.AddrPort, nil)
+}

--- a/tcp-keepalive/internal/server/metrics.go
+++ b/tcp-keepalive/internal/server/metrics.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	internalmetrics "github.com/neco-containers/tcp-keepalive/internal/metrics"
+
+	"github.com/VictoriaMetrics/metrics"
+)
+
+var (
+	receiveSuccessTotal *metrics.Counter
+	receiveErrorTotal   *metrics.Counter
+	sendSuccessTotal    *metrics.Counter
+	sendErrorTotal      *metrics.Counter
+)
+
+func initMetrics() {
+	receiveSuccessTotal = metrics.NewCounter(`receive_total{role="server",result="success"}`)
+	receiveErrorTotal = metrics.NewCounter(`receive_total{role="server",result="error"}`)
+	sendSuccessTotal = metrics.NewCounter(`send_total{role="server",result="success"}`)
+	sendErrorTotal = metrics.NewCounter(`send_total{role="server",result="error"}`)
+}
+
+type Metrics struct {
+	*internalmetrics.Metrics
+}
+
+func NewMetrics(cfg *internalmetrics.Config) (*Metrics, error) {
+	m, err := internalmetrics.NewMetrics(cfg)
+	if err != nil {
+		return nil, err
+	}
+	initMetrics()
+	return &Metrics{m}, nil
+}


### PR DESCRIPTION
This PR adds the metrics below.

- `connection`
  - A TCP connection status
- `receive_total`
  - num of receive messages
- `send_total`
  - num of send messages
- `retry_count`
  - num of consecutive retries
- `retry_total`
  - num of total retries
