### PR TITLE
cleanup: use tool.mk in admission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 cover.out
 vendor
 /.idea
+/bin

--- a/admission/Makefile
+++ b/admission/Makefile
@@ -83,27 +83,9 @@ SETUP_ENVTEST = $(PROJECT_DIR)/bin/setup-envtest
 setup-envtest:
 	$(call go-install-tool,$(SETUP_ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_BRANCH))
 
-# Download staticcheck locally if necessary
-STATICCHECK = $(PROJECT_DIR)/bin/staticcheck
-.PHONY: staticcheck
-staticcheck:
-	$(call go-install-tool,$(STATICCHECK),honnef.co/go/tools/cmd/staticcheck@latest)
-
 .PHONY: clean
 clean:
 	rm -rf bin
 	rm -f config/crd/bases/*
 
-# go-install-tool will 'go install' any package $2 and install it to $1.
-PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-define go-install-tool
-@[ -f $(1) ] || { \
-set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
-rm -rf $$TMP_DIR ;\
-}
-endef
+include ../tool.mk


### PR DESCRIPTION
- Use tool.mk ins admission directory and remove unnecessary functions.
- Update .gitignore not to include binaries in git repository.