### PR TITLE
squid-exporter: fix kubectl url

### DIFF
--- a/squid-exporter/e2e/Makefile
+++ b/squid-exporter/e2e/Makefile
@@ -42,7 +42,7 @@ $(KIND): $(BIN_DIR)
 .PHONY: kubectl
 kubectl: $(KUBECTL)
 $(KUBECTL): $(BIN_DIR)
-	$(CURL) -o $(BIN_DIR)/kubectl https://storage.googleapis.com/kubernetes-release/release/v$(E2ETEST_K8S_VERSION)/bin/$(OS)/$(ARCH)/kubectl && chmod a+x $(BIN_DIR)/kubectl
+	$(CURL) -o $(BIN_DIR)/kubectl https://dl.k8s.io/v$(E2ETEST_K8S_VERSION)/bin/$(OS)/$(ARCH)/kubectl && chmod a+x $(BIN_DIR)/kubectl
 
 .PHONY: bin_dir
 $(BIN_DIR):


### PR DESCRIPTION
Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
