### PR TITLE
Use `CYBOZU_NECO_PAT`

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -10,7 +10,7 @@ jobs:
   update-go-versions:
     runs-on: ubuntu-24.04
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.CYBOZU_NECO_PAT }}
       UBUNTU_VERSIONS: "22.04 24.04"
       GO_MAJOR_VERSIONS: "1.23 1.24"
     permissions:


### PR DESCRIPTION
### what
- Resolve the issue of some CIs not turning on golang auto-update.
- I assume that the PAT has been issued before and will work only by modifying the code.

* [`.github/workflows/update.yaml`](diffhunk://#diff-41f5d174d53392c4b8bb62f2b04f1126a47e9d682555daec2a27891abc4da327L13-R13): Changed the `GH_TOKEN` environment variable to use `secrets.CYBOZU_NECO_PAT` instead of `secrets.GITHUB_TOKEN`.…BOZU_NECO_PAT