### PR TITLE
cilium: fix package dependency

### DIFF
--- a/cilium/Dockerfile
+++ b/cilium/Dockerfile
@@ -27,6 +27,11 @@ FROM ${GOLANG_IMAGE} AS cybozu-golang
 FROM ${UBUNTU_IMAGE} AS cilium-compiler
 COPY src/image-tools/images/compilers/install-deps.sh /tmp/install-deps.sh
 
+# Workaround
+RUN mv /tmp/install-deps.sh /tmp/install-deps-original.sh \
+    && cat /tmp/install-deps-original.sh | grep -v libelf-dev:arm64 > /tmp/install-deps.sh \
+    && chmod +x /tmp/install-deps.sh
+
 RUN /tmp/install-deps.sh
 
 # -------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR removes `libelf-dev:arm64` from the install script.
https://wiki.debian.org/Multiarch/HOWTO

This doesn't update `TAG` because the latest version was not created.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
