### PR TITLE
Reduce ephemeral storage request to 10Mi

### DIFF
--- a/admission/README.md
+++ b/admission/README.md
@@ -82,7 +82,7 @@ However, topolvm-controller can remove PersistentVolumeClaims, even if they are 
 PodMutator
 ----------
 
-PodMutator mutates Pod manifests to specify local ephemeral storage limit to 1GiB and request to 200MiB for each container.
+PodMutator mutates Pod manifests to specify local ephemeral storage limit to 1GiB and request to 10MiB for each container.
 The purpose of this mutator is to prevent Pods from overuse of local ephemeral storage.
 
 If `VPOD_EPHEMERAL_STORAGE_PERMISSIVE=true` envvar is set, local ephemeral storage requests and limits specified in 

--- a/admission/hooks/mutate_pod.go
+++ b/admission/hooks/mutate_pod.go
@@ -15,7 +15,7 @@ import (
 // +kubebuilder:webhook:path=/mutate-pod,mutating=true,failurePolicy=fail,sideEffects=None,groups="",resources=pods,verbs=create,versions=v1,name=mpod.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var (
-	ephemeralStorageRequest = resource.MustParse("200Mi")
+	ephemeralStorageRequest = resource.MustParse("10Mi")
 	ephemeralStorageLimit   = resource.MustParse("1Gi")
 )
 

--- a/admission/hooks/mutate_pod_test.go
+++ b/admission/hooks/mutate_pod_test.go
@@ -43,7 +43,7 @@ spec:
 		out := createPod(po)
 		Expect(out.Spec.Containers[0].Resources.Requests).Should(HaveKey(v1.ResourceEphemeralStorage))
 		Expect(out.Spec.Containers[0].Resources.Limits).Should(HaveKey(v1.ResourceEphemeralStorage))
-		Expect(out.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("200Mi")))
+		Expect(out.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("10Mi")))
 		Expect(out.Spec.Containers[0].Resources.Limits[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("1Gi")))
 	})
 
@@ -71,11 +71,11 @@ spec:
 		out := createPod(po)
 		Expect(out.Spec.Containers[0].Resources.Requests).Should(HaveKey(v1.ResourceEphemeralStorage))
 		Expect(out.Spec.Containers[0].Resources.Limits).Should(HaveKey(v1.ResourceEphemeralStorage))
-		Expect(out.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("200Mi")))
+		Expect(out.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("10Mi")))
 		Expect(out.Spec.Containers[0].Resources.Limits[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("1Gi")))
 		Expect(out.Spec.InitContainers[0].Resources.Requests).Should(HaveKey(v1.ResourceEphemeralStorage))
 		Expect(out.Spec.InitContainers[0].Resources.Limits).Should(HaveKey(v1.ResourceEphemeralStorage))
-		Expect(out.Spec.InitContainers[0].Resources.Requests[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("200Mi")))
+		Expect(out.Spec.InitContainers[0].Resources.Requests[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("10Mi")))
 		Expect(out.Spec.InitContainers[0].Resources.Limits[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("1Gi")))
 	})
 
@@ -122,9 +122,9 @@ spec:
 			Expect(out.Spec.InitContainers[0].Resources.Requests[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("100Mi")))
 			Expect(out.Spec.InitContainers[0].Resources.Limits[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("100Mi")))
 		} else {
-			Expect(out.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("200Mi")))
+			Expect(out.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("10Mi")))
 			Expect(out.Spec.Containers[0].Resources.Limits[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("1Gi")))
-			Expect(out.Spec.InitContainers[0].Resources.Requests[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("200Mi")))
+			Expect(out.Spec.InitContainers[0].Resources.Requests[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("10Mi")))
 			Expect(out.Spec.InitContainers[0].Resources.Limits[v1.ResourceEphemeralStorage]).Should(Equal(resource.MustParse("1Gi")))
 		}
 	})


### PR DESCRIPTION
This PR reduces the default resource requests of the local ephemeral storage added by admission from `200MiB` to `10MiB`.
In our environment, the local ephemeral storage is rarely used, and it is excessive even at 200 MiB.