### PR TITLE
Update go to 1.24.4

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -290,7 +290,7 @@ jobs:
         job: ${{ fromJson(needs.prepare_matrix.outputs.jobs) }}
     runs-on: ubuntu-22.04
     env:
-      go-version: "1.24.1"
+      go-version: "1.24.4"
     steps:
       - uses: actions/checkout@v4
       - name: Setup build environment


### PR DESCRIPTION
This PR updates the Go version used in CI to v1.24.4.

This fix is to resolve the following error in CI when updating the `go.mod` of the in-house programs in this repository (neco-admission, etc.).
```
/home/runner/work/neco-containers/neco-containers/bin/staticcheck ./...
-: module requires at least go1.24.4, but Staticcheck was built with go1.24.1 (compile)
```