### PR TITLE
ceph: remove ceph version parameter from build_ceph job

### DIFF
--- a/.github/actions/build_ceph/action.yaml
+++ b/.github/actions/build_ceph/action.yaml
@@ -4,9 +4,6 @@ inputs:
   github_token:
     description: "GitHub Token"
     required: true
-  version:
-    description: "ceph version"
-    required: true
 runs:
   using: composite
   steps:
@@ -24,7 +21,13 @@ runs:
       if: ${{ steps.prepare.outputs.build }}
       shell: bash
       run: |
-        sudo ./build.sh ${{ inputs.version }}
+        TAG_CONTENT=$(cat TAG)
+        if ! echo "${TAG_CONTENT}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+          echo "Invalid TAG file format: ${TAG_CONTENT}"
+          exit 1
+        fi
+        VERSION=$(echo "${TAG_CONTENT}" | cut -d '.' -f1-3)
+        sudo ./build.sh ${VERSION}
         sudo mv src/workspace .
       working-directory: ceph
     - name: Build and push

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -329,7 +329,6 @@ jobs:
       uses: ./.github/actions/build_ceph
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        version: 19.2.3
 
   build_cilium:
     runs-on: neco-containers-ubuntu-22.04

--- a/maintenance.md
+++ b/maintenance.md
@@ -331,8 +331,7 @@ The libsystemd version should be the same with the one running on [the stable Fl
 2. Check the [build ceph](https://docs.ceph.com/en/latest/install/build-ceph/) document and [README.md](https://github.com/ceph/ceph/blob/main/README.md).
    1. If other instructions are needed for `ceph/build.sh`, add the instructions.
    2. If there are ceph runtime packages or required tool changes, update Dockerfile.
-3. Update the `version` argument on the `build-ceph` job in the `build_ceph` job in the Github Actions `main` workflow.
-4. Update `BRANCH` and `TAG` files.
+3. Update `BRANCH` and `TAG` files.
 
 ### Create a patched image from the specific version
 


### PR DESCRIPTION
The Ceph version is specified in two places: the TAG file and
the build_ceph job in the main workflow. Since these cannot be
configured independently, this commit replaces the parameter
specification in the ceph_build job with a process that
references the contents of the TAG file.

Signed-off-by: Shinya Hayashi <shinya-hayashi@cybozu.co.jp>
