### PR TITLE
lock go installed tools versions

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -34,4 +34,4 @@ runs:
         go-version-file: ${{ inputs.go-version-file }}
     - name: Install container-tag-exists
       shell: bash
-      run: go install github.com/Hsn723/container-tag-exists@latest
+      run: go install github.com/Hsn723/container-tag-exists@v1.2.4

--- a/cilium/Dockerfile
+++ b/cilium/Dockerfile
@@ -147,7 +147,7 @@ ENV GOROOT /usr/local/go
 ENV GOPATH /go
 ENV PATH "${GOROOT}/bin:${GOPATH}/bin:${PATH}"
 
-RUN CGO_ENABLED=0 go install github.com/go-delve/delve/cmd/dlv@latest
+RUN CGO_ENABLED=0 go install github.com/go-delve/delve/cmd/dlv@v1.26.3
 
 WORKDIR /go/src/github.com/cilium/cilium/images/builder
 RUN --mount=type=bind,readwrite,source=src/cilium/images/builder,target=/go/src/github.com/cilium/cilium/images/builder \

--- a/maintenance.md
+++ b/maintenance.md
@@ -452,6 +452,7 @@ gitGraph
 4. Check the upstream `Dockerfile`s to make necessary changes for `neco-containers/cilium`.
    1. Run `make urls`. It displays all the URLs of the upstream `Dockerfile`s.
    2. All the build specification is written in `neco-containers/cilium/Dockerfile`. Please check the header comment of the file to find the mapping of our build targets and the upstream ones.
+   3. Update github.com/go-delve/delve/cmd/dlv version. Upstream may be using @latest but we must specify a version.
 5. Update cilium-cli version in `e2e/Makefile`. See cilium-cli's [README](https://github.com/cilium/cilium-cli?tab=readme-ov-file#releases) to make sure that the cilium-cli version is compatible with the cilium version.
 6. Build `ghcr.io/cybozu/cilium` and see the result.
    1. Run `make build` to build.


### PR DESCRIPTION
- **cilium: lock delve version**
- **setup: lock container-tag-exists version**
