### PR TITLE
Stop using container-tag-exists

### DIFF
--- a/.github/actions/prepare_build_params/action.yaml
+++ b/.github/actions/prepare_build_params/action.yaml
@@ -73,9 +73,8 @@ runs:
         DIR=${{ steps.dir.outputs.dir }}
         IMAGE=${{ inputs.container-image }}
         TAG=$(cat ${DIR}/TAG)
-        FOUND=$(container-tag-exists ghcr.io/cybozu/${IMAGE} ${TAG})
-        # The stdout should be either "" or "found".
-        if [ "${FOUND}" = "" ]; then
+        FOUND=$(./tag_exists ghcr.io/cybozu/${IMAGE} ${TAG})
+        if [ "${FOUND}" = "false" ]; then
           echo "tag=ghcr.io/cybozu/${IMAGE}:${TAG}" >> $GITHUB_OUTPUT
 
           if [ -f ${DIR}/BRANCH ]; then

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -32,9 +32,6 @@ runs:
       with:
         go-version: ${{ inputs.go-version }}
         go-version-file: ${{ inputs.go-version-file }}
-    - name: Install container-tag-exists
-      shell: bash
-      run: go install github.com/Hsn723/container-tag-exists@v1.2.4
     - name: Setup aqua
       uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
       with:

--- a/tag_exists
+++ b/tag_exists
@@ -1,0 +1,28 @@
+#!/bin/sh -e
+# tag_exists ghcr.io/<ORG>/<PACKAGE> <TAG>
+
+if [ $# -ne 2 ]; then
+    echo "Error: tag_exists needs two arguments" >&2
+    exit 1
+fi
+
+IMAGE="$1"
+TAG="$2"
+
+REGISTRY=$(echo "${IMAGE}" | cut -d'/' -f1)
+if [ "${REGISTRY}" != "ghcr.io" ]; then
+    echo "Error: unsupported registry '${REGISTRY}' (only 'ghcr.io' is allowed)" >&2
+    exit 1
+fi
+
+ORG=$(echo "${IMAGE}" | cut -d/ -f2)
+PACKAGE=$(echo "${IMAGE}" | cut -d/ -f3-)
+PACKAGE_ENC=$(echo "${PACKAGE}" | jq -Rr '@uri')
+if [ -z "${ORG}" ] || [ -z "${PACKAGE_ENC}" ]; then
+    echo "Error: invalid image format (expected: ghcr.io/<org>/<package>)" >&2
+    exit 1
+fi
+
+# output "true" or "false" by `jq any()`
+VERSIONS=$(gh api "/orgs/${ORG}/packages/container/${PACKAGE_ENC}/versions?per_page=100" --paginate --slurp)
+echo "${VERSIONS}" | jq --arg tag "$TAG" 'any((add // [])[].metadata.container.tags[]; . == $tag)'


### PR DESCRIPTION
part of https://github.com/cybozu-private/neco-tasks/issues/1045

container-tag-existsの利用を停止します。
ghcr.ioのタグの有無をチェックするスクリプト(`tag_exists`)を作り、それを使うようにします。

`tag_exists`の内容はneco-containers-private(https://github.com/cybozu-private/neco-containers-private/pull/22 で追加したもの)と同じです。