### PR TITLE
Secure admission

### DIFF
--- a/admission/Makefile
+++ b/admission/Makefile
@@ -1,16 +1,11 @@
-CONTROLLER_TOOLS_VERSION = 0.20.1
-KUSTOMIZE_VERSION = 5.8.1
 # Contour v1.33.5
 CONTOUR_COMMIT_HASH := 2713ad0e0ebd5d192a53803cef4c1c3a69692b1c
 # Argo CD v3.4.3
 ARGOCD_COMMIT_HASH := 1801122b4391cad4961301f787006dc9a88c2dd3
 # Grafana Operator v5.18.0
 GRAFANA_OPERATOR_COMMIT_HASH := de1156accb9c4529cbdb536a054b9c4bb5ee759d
-ENVTEST_K8S_VERSION = 1.35.0
 
-# Specify envtest branch according to controller-runtime version
-CONTROLLER_RUNTIME_VERSION := $(shell awk '$$1 == "sigs.k8s.io/controller-runtime" {print substr($$2, 2)}' go.mod)
-ENVTEST_BRANCH := release-$(shell echo $(CONTROLLER_RUNTIME_VERSION) | cut -d "." -f 1-2)
+ENVTEST_K8S_VERSION = 1.35.0
 
 # Set the shell used to bash for better error handling.
 SHELL = /bin/bash
@@ -28,7 +23,7 @@ crds:
 
 # Run tests, and set up envtest if not done already.
 .PHONY: test
-test: crds simple-test setup-envtest
+test: crds simple-test setup
 	{ \
 	source <($(SETUP_ENVTEST) use -p env $(ENVTEST_K8S_VERSION)) && \
 	ENABLE_PODCPUREQUESTREDUCE_MUTATION=true go test ./... -coverprofile cover.out ; \
@@ -41,9 +36,9 @@ test: crds simple-test setup-envtest
 	}
 
 .PHONY: simple-test
-simple-test: staticcheck
+simple-test: setup
 	test -z "$$(gofmt -s -l . | tee /dev/stderr)"
-	$(STATICCHECK) ./...
+	staticcheck ./...
 	go vet ./...
 
 .PHONY: check-generate
@@ -60,35 +55,19 @@ build:
 
 # Generate manifests e.g. CRD, RBAC etc.
 .PHONY: manifests
-manifests: controller-gen
-	$(CONTROLLER_GEN) rbac:roleName=neco-admission webhook paths="./..."
+manifests: setup
+	controller-gen rbac:roleName=neco-admission webhook paths="./..."
 
 # Generate code
 .PHONY: generate
-generate: controller-gen
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
-
-# Download controller-gen locally if necessary
-CONTROLLER_GEN = $(CURDIR)/bin/controller-gen
-.PHONY: controller-gen
-controller-gen:
-	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v$(CONTROLLER_TOOLS_VERSION))
-
-# Download kustomize locally if necessary
-KUSTOMIZE = $(CURDIR)/bin/kustomize
-.PHONY: kustomize
-kustomize:
-	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v$(shell echo $(KUSTOMIZE_VERSION) | cut -d "." -f1)@v$(KUSTOMIZE_VERSION))
-
-# Download setup-envtest locally if necessary
-SETUP_ENVTEST = $(CURDIR)/bin/setup-envtest
-.PHONY: setup-envtest
-setup-envtest:
-	$(call go-install-tool,$(SETUP_ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_BRANCH))
+generate: setup
+	controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: clean
 clean:
 	rm -rf bin
 	rm -f config/crd/bases/*
 
-include ../tool.mk
+.PHONY: setup
+setup:
+	aqua i -l

--- a/admission/Makefile
+++ b/admission/Makefile
@@ -1,9 +1,11 @@
 CONTROLLER_TOOLS_VERSION = 0.20.1
 KUSTOMIZE_VERSION = 5.8.1
-CONTOUR_VERSION = 1.33.5
+# Contour v1.33.5
+CONTOUR_COMMIT_HASH := 2713ad0e0ebd5d192a53803cef4c1c3a69692b1c
 # Argo CD v3.4.3
-ARGOCD_COMMIT_HASH = 1801122b4391cad4961301f787006dc9a88c2dd3
-GRAFANA_OPERATOR_VERSION = 5.18.0
+ARGOCD_COMMIT_HASH := 1801122b4391cad4961301f787006dc9a88c2dd3
+# Grafana Operator v5.18.0
+GRAFANA_OPERATOR_COMMIT_HASH := de1156accb9c4529cbdb536a054b9c4bb5ee759d
 ENVTEST_K8S_VERSION = 1.35.0
 
 # Specify envtest branch according to controller-runtime version
@@ -20,9 +22,9 @@ all: build
 .PHONY: crds
 crds:
 	mkdir -p config/crd/bases
-	curl -fsL -o config/crd/bases/contour.yaml https://raw.githubusercontent.com/projectcontour/contour/v$(CONTOUR_VERSION)/examples/contour/01-crds.yaml
+	curl -fsL -o config/crd/bases/contour.yaml https://raw.githubusercontent.com/projectcontour/contour/$(CONTOUR_COMMIT_HASH)/examples/contour/01-crds.yaml
 	curl -fsL -o config/crd/bases/application.yaml https://raw.githubusercontent.com/argoproj/argo-cd/$(ARGOCD_COMMIT_HASH)/manifests/crds/application-crd.yaml
-	curl -fsL -o config/crd/bases/grafana-operator.yaml https://github.com/grafana/grafana-operator/raw/v$(GRAFANA_OPERATOR_VERSION)/deploy/kustomize/base/crds.yaml
+	curl -fsL -o config/crd/bases/grafana-operator.yaml https://raw.githubusercontent.com/grafana/grafana-operator/$(GRAFANA_OPERATOR_COMMIT_HASH)/deploy/kustomize/base/crds.yaml
 
 # Run tests, and set up envtest if not done already.
 .PHONY: test

--- a/admission/Makefile
+++ b/admission/Makefile
@@ -5,11 +5,12 @@ ARGOCD_COMMIT_HASH := 1801122b4391cad4961301f787006dc9a88c2dd3
 # Grafana Operator v5.18.0
 GRAFANA_OPERATOR_COMMIT_HASH := de1156accb9c4529cbdb536a054b9c4bb5ee759d
 
-ENVTEST_K8S_VERSION = 1.35.0
+ENVTEST_K8S_VERSION := 1.35.0
+ENVTEST_USE := setup-envtest use -p env $(ENVTEST_K8S_VERSION)
 
 # Set the shell used to bash for better error handling.
-SHELL = /bin/bash
-.SHELLFLAGS = -e -o pipefail -c
+SHELL := /bin/bash
+.SHELLFLAGS := -e -o pipefail -c
 
 .PHONY: all
 all: build
@@ -24,16 +25,12 @@ crds:
 # Run tests, and set up envtest if not done already.
 .PHONY: test
 test: crds simple-test setup
-	{ \
-	source <($(SETUP_ENVTEST) use -p env $(ENVTEST_K8S_VERSION)) && \
-	ENABLE_PODCPUREQUESTREDUCE_MUTATION=true go test ./... -coverprofile cover.out ; \
-	}
+	source <($(ENVTEST_USE)) && \
+		ENABLE_PODCPUREQUESTREDUCE_MUTATION=true go test ./... -coverprofile cover.out
 	# TEST_PERMISSIVE test and NO_HTTPPROXY_MUTATION test can run at the same time
 	# because they do not affect each other.
-	{ \
-	source <($(SETUP_ENVTEST) use -p env $(ENVTEST_K8S_VERSION)) && \
-	TEST_PERMISSIVE=true NO_HTTPPROXY_MUTATION=true go test -v -count 1 ./... ; \
-	}
+	source <($(ENVTEST_USE)) && \
+		TEST_PERMISSIVE=true NO_HTTPPROXY_MUTATION=true go test -v -count 1 ./...
 
 .PHONY: simple-test
 simple-test: setup

--- a/admission/aqua-checksums.json
+++ b/admission/aqua-checksums.json
@@ -41,26 +41,6 @@
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/kubernetes-sigs/kustomize/kustomize/v5.8.1/kustomize_v5.8.1_darwin_amd64.tar.gz",
-      "checksum": "EE7CF0C1E3592AA7BB66BA82B359933A95E7F2E0B36E5F53ED0A4535B017F2F8",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/kubernetes-sigs/kustomize/kustomize/v5.8.1/kustomize_v5.8.1_darwin_arm64.tar.gz",
-      "checksum": "8886F8A78474E608CC81234F729FDA188A9767DA23E28925802F00ECE2BAB288",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/kubernetes-sigs/kustomize/kustomize/v5.8.1/kustomize_v5.8.1_linux_amd64.tar.gz",
-      "checksum": "029A7F0F4E1932C52A0476CF02A0FD855C0BB85694B82C338FC648DCB53A819D",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/kubernetes-sigs/kustomize/kustomize/v5.8.1/kustomize_v5.8.1_linux_arm64.tar.gz",
-      "checksum": "0953EA3E476F66D6DDFCD911D750F5167B9365AA9491B2326398E289FEF2C142",
-      "algorithm": "sha256"
-    },
-    {
       "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.486.0/registry.yaml",
       "checksum": "C37EB2C6D865B586E781B2410FC7EC52F699EF8FC482410E6A9167152EDA330F",
       "algorithm": "sha256"

--- a/admission/aqua-checksums.json
+++ b/admission/aqua-checksums.json
@@ -1,0 +1,69 @@
+{
+  "checksums": [
+    {
+      "id": "github_release/github.com/dominikh/go-tools/2026.1/staticcheck_darwin_amd64.tar.gz",
+      "checksum": "4B1483A2B21D555BC04DEDB00823143DCA66D5E53AC98DB8E55AE6DF87BEBFAD",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/dominikh/go-tools/2026.1/staticcheck_darwin_arm64.tar.gz",
+      "checksum": "F71553886FE4BB313DA317D7ABC3E16FE3CAE2DBA54F1E07A94A1AE160BECED2",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/dominikh/go-tools/2026.1/staticcheck_linux_amd64.tar.gz",
+      "checksum": "9242B4BF5B9F5481FD720EC6D1018B38FBFFE0E2730E498923C6E8053E8576BE",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/dominikh/go-tools/2026.1/staticcheck_linux_arm64.tar.gz",
+      "checksum": "DDE37C023073AFF5D910A85536A80B92A2AE0DB75F6A89AFCEC1272C4FABD6FD",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/controller-runtime/v0.23.3/setup-envtest-darwin-amd64",
+      "checksum": "AF4F2F55145370FF06F0EDEA64FDCD661E1E9B1197E1186751B96078B7E1CF05",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/controller-runtime/v0.23.3/setup-envtest-darwin-arm64",
+      "checksum": "8FF44A983A5E834187EBB42EE9B97C6604186F85C0BD862A23B4EE52AC859DD9",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/controller-runtime/v0.23.3/setup-envtest-linux-amd64",
+      "checksum": "90564D1CA65FEDDD5E0CC817632BA55EE82727212ED455245146B409E8A6BC16",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/controller-runtime/v0.23.3/setup-envtest-linux-arm64",
+      "checksum": "4599BE79ED56DA1869EED73DD7AE956954519FD6CDDE23227CE6844F0B7705AF",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kustomize/kustomize/v5.8.1/kustomize_v5.8.1_darwin_amd64.tar.gz",
+      "checksum": "EE7CF0C1E3592AA7BB66BA82B359933A95E7F2E0B36E5F53ED0A4535B017F2F8",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kustomize/kustomize/v5.8.1/kustomize_v5.8.1_darwin_arm64.tar.gz",
+      "checksum": "8886F8A78474E608CC81234F729FDA188A9767DA23E28925802F00ECE2BAB288",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kustomize/kustomize/v5.8.1/kustomize_v5.8.1_linux_amd64.tar.gz",
+      "checksum": "029A7F0F4E1932C52A0476CF02A0FD855C0BB85694B82C338FC648DCB53A819D",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kustomize/kustomize/v5.8.1/kustomize_v5.8.1_linux_arm64.tar.gz",
+      "checksum": "0953EA3E476F66D6DDFCD911D750F5167B9365AA9491B2326398E289FEF2C142",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.486.0/registry.yaml",
+      "checksum": "C37EB2C6D865B586E781B2410FC7EC52F699EF8FC482410E6A9167152EDA330F",
+      "algorithm": "sha256"
+    }
+  ]
+}

--- a/admission/aqua.yaml
+++ b/admission/aqua.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+checksum:
+  enabled: true
+  require_checksum: true
+  supported_envs:
+  - darwin
+  - linux
+registries:
+- type: standard
+  ref: v4.486.0 # renovate: depName=aquaproj/aqua-registry
+packages:
+- name: kubernetes-sigs/kustomize@kustomize/v5.8.1
+- name: kubernetes-sigs/controller-tools/controller-gen@v0.20.1
+# align with controller-runtime version in go.mod
+- name: kubernetes-sigs/controller-runtime/setup-envtest@v0.23.3
+- name: dominikh/go-tools/staticcheck@2026.1

--- a/admission/aqua.yaml
+++ b/admission/aqua.yaml
@@ -12,7 +12,6 @@ registries:
 - type: standard
   ref: v4.486.0 # renovate: depName=aquaproj/aqua-registry
 packages:
-- name: kubernetes-sigs/kustomize@kustomize/v5.8.1
 - name: kubernetes-sigs/controller-tools/controller-gen@v0.20.1
 # align with controller-runtime version in go.mod
 - name: kubernetes-sigs/controller-runtime/setup-envtest@v0.23.3

--- a/maintenance.md
+++ b/maintenance.md
@@ -115,11 +115,12 @@ In case of components whose Go source code are in neco-containers, all dependent
 In Kubernetes update:
 
 1. Update the following version variables in `Makefile`.
-   - `CONTROLLER_TOOLS_VERSION`
-   - `KUSTOMIZE_VERSION`
    - `ENVTEST_K8S_VERSION`
-2. Upgrade direct dependencies listed in `go.mod`. Use `go get` or your editor's function.
-3. Generate code and manifests.
+2. Update the following packages in `aqua.yaml`.
+   - `kubernetes-sigs/controller-tools/controller-gen`
+   - `kubernetes-sigs/controller-runtime/setup-envtest`
+3. Upgrade direct dependencies listed in `go.mod`. Use `go get` or your editor's function.
+4. Generate code and manifests.
 
    ```bash
    cd $GOPATH/src/github.com/cybozu/neco-containers/admission
@@ -127,22 +128,22 @@ In Kubernetes update:
    # Commit, if there are any updated files.
    ```
 
-4. Confirm build and test are green.
+5. Confirm build and test are green.
 
    ```bash
    make build test
    ```
 
-5. Update `TAG` file.
+6. Update `TAG` file.
 
 ![Regular Update](./regular_update.svg)
 
 In Regular update, do the following as part of the update of each CRD-providing product:
 
-1. Update a matching version variable from the following in `Makefile`.
-   - `CONTOUR_VERSION`
-   - `ARGOCD_VERSION`
-   - `GRAFANA_OPERATOR_VERSION`
+1. Update the matching commit hash variables and comments from the following in `Makefile`.
+   - `CONTOUR_COMMIT_HASH`
+   - `ARGOCD_COMMIT_HASH`
+   - `GRAFANA_OPERATOR_COMMIT_HASH`
 2. Modify the code to match the new CRDs if CRDs are changed.
    - The code which depended on the CRDs are in the [hook](https://github.com/cybozu/neco-containers/tree/main/admission/hooks) directory.
    - And let's use `Unstructured` instead of use golang library. Take a look at [this PR](https://github.com/cybozu/neco-containers/pull/339/files).


### PR DESCRIPTION
## Changed

- migrate the tool management from Makefile-based `go install` to aqua to improve security and maintainability
- use commit hashes to fetch CRDs
  - Contour: https://github.com/projectcontour/contour/tree/v1.33.5
  - Argo CD: https://github.com/argoproj/argo-cd/tree/v3.4.3
  - Grafana Operator: https://github.com/grafana/grafana-operator/tree/v5.18.0
- remove kustomize installation, which appears to have been introduced by kubebuilder but is not actually used

    ```console
    takahiro_yamada@pdx-ytk-dev:~/work/cybozu/neco-containers$ 
    k8s:> grep -rni kustomize ./admission/ | grep -v config/crd/bases
    ./admission/config/default/kustomization.yaml:46:# the following config is for teaching kustomize how to do var substitution
    ./admission/config/certmanager/certificate.yaml:15:  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
    ./admission/config/certmanager/certificate.yaml:18:  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
    ./admission/config/certmanager/certificate.yaml:25:  secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize
    ./admission/config/certmanager/kustomizeconfig.yaml:1:# This configuration is for teaching kustomize how to update name ref and var substitution 
    ./admission/config/certmanager/kustomization.yaml:5:- kustomizeconfig.yaml
    takahiro_yamada@pdx-ytk-dev:~/work/cybozu/neco-containers$ 
    ```

## Note

`TAG` is not bumped since this change is not related to the admission itself.

## Tests

All tests passed as shown below.

```console
takahiro_yamada@pdx-ytk-dev:~/work/cybozu/neco-containers/admission$ 
k8s:> make clean
rm -rf bin
rm -f config/crd/bases/*
takahiro_yamada@pdx-ytk-dev:~/work/cybozu/neco-containers/admission$ 
k8s:> make generate manifests
aqua i -l
controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
controller-gen rbac:roleName=neco-admission webhook paths="./..."
takahiro_yamada@pdx-ytk-dev:~/work/cybozu/neco-containers/admission$ 
k8s:> make build test
CGO_ENABLED=0 go build -o bin/neco-admission -ldflags="-w -s" main.go
mkdir -p config/crd/bases
curl -fsL -o config/crd/bases/contour.yaml https://raw.githubusercontent.com/projectcontour/contour/2713ad0e0ebd5d192a53803cef4c1c3a69692b1c/examples/contour/01-crds.yaml
curl -fsL -o config/crd/bases/application.yaml https://raw.githubusercontent.com/argoproj/argo-cd/1801122b4391cad4961301f787006dc9a88c2dd3/manifests/crds/application-crd.yaml
curl -fsL -o config/crd/bases/grafana-operator.yaml https://raw.githubusercontent.com/grafana/grafana-operator/de1156accb9c4529cbdb536a054b9c4bb5ee759d/deploy/kustomize/base/crds.yaml
aqua i -l
test -z "$(gofmt -s -l . | tee /dev/stderr)"
staticcheck ./...
go vet ./...
source <(setup-envtest use -p env 1.35.0) && \
        ENABLE_PODCPUREQUESTREDUCE_MUTATION=true go test ./... -coverprofile cover.out
        github.com/cybozu/neco-containers/admission             coverage: 0.0% of statements
        github.com/cybozu/neco-containers/admission/cmd         coverage: 0.0% of statements
ok      github.com/cybozu/neco-containers/admission/hooks       7.717s  coverage: 83.0% of statements
# TEST_PERMISSIVE test and NO_HTTPPROXY_MUTATION test can run at the same time
# because they do not affect each other.
source <(setup-envtest use -p env 1.35.0) && \
        TEST_PERMISSIVE=true NO_HTTPPROXY_MUTATION=true go test -v -count 1 ./...
?       github.com/cybozu/neco-containers/admission     [no test files]
?       github.com/cybozu/neco-containers/admission/cmd [no test files]
=== RUN   TestAPIs
Running Suite: Webhook Suite - /home/takahiro_yamada/work/cybozu/neco-containers/admission/hooks
================================================================================================
Random Seed: 1781480696

Will run 52 of 52 specs
•••••••••••••••••••••••••••••••••••••••••••••••••••I0614 23:45:02.739703 1157278 warnings.go:107] "Warning: image busybox is not trusted"
•

Ran 52 of 52 Specs in 7.191 seconds
SUCCESS! -- 52 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestAPIs (7.19s)
=== RUN   TestIgnoreGitSuffix
--- PASS: TestIgnoreGitSuffix (0.00s)
PASS
ok      github.com/cybozu/neco-containers/admission/hooks       7.214s
takahiro_yamada@pdx-ytk-dev:~/work/cybozu/neco-containers/admission$ 
```