### PR TITLE
fix trivy verification

### DIFF
--- a/.github/actions/setup-cosign/action.yaml
+++ b/.github/actions/setup-cosign/action.yaml
@@ -14,7 +14,7 @@ runs:
           sudo apt-get install -y --no-install-recommends \
             gettext-base
         fi
-    - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003  # v4.1.1
+    - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
     - run: |
         cosign version
       shell: bash

--- a/.github/actions/setup-trivy/action.yaml
+++ b/.github/actions/setup-trivy/action.yaml
@@ -36,6 +36,7 @@ runs:
         cosign verify-blob-attestation \
           --bundle bundle.json \
           --new-bundle-format \
+          --type slsaprovenance1 \
           --certificate-identity "https://github.com/aquasecurity/trivy/.github/workflows/reusable-release.yaml@refs/tags/v${TRIVY_VERSION}" \
           --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
           "${ARTIFACT}"

--- a/.github/actions/setup-trivy/action.yaml
+++ b/.github/actions/setup-trivy/action.yaml
@@ -6,7 +6,31 @@ inputs:
 runs:
   using: composite
   steps:
-    - env:
+    - name: Install s2d, snappy compatible unarchiver
+      env:
+        S2_VERSION: "v1.19.0"
+        S2_CHECKSUM: "60ea3520edd8be159f03624cbfa2ecf3d4c8f01c5597175102ef783560174444"
+      shell: bash
+      run: |
+        set -x
+        S2_RELEASE_URL="https://github.com/klauspost/compress/releases/download/${S2_VERSION}"
+        S2_DEB="s2_package__linux_amd64.deb"
+        ARTIFACT="/tmp/${S2_DEB}"
+        echo "::group::Download artifacts"
+        wget -O "${ARTIFACT}" "${S2_RELEASE_URL}/${S2_DEB}"
+        echo "::endgroup::"
+
+        echo "::group::Check checksum"
+        echo "${S2_CHECKSUM}  ${ARTIFACT}" | sha256sum -c -
+        echo "::endgroup::"
+
+        echo "::group::Install s2"
+        sudo apt-get install -y "${ARTIFACT}"
+        rm -f "${ARTIFACT}"
+        s2d -help
+        echo "::endgroup::"
+    - name: Install Trivy
+      env:
         TRIVY_VERSION: "${{ inputs.trivy-version }}"
       run: |
         set -x
@@ -31,8 +55,9 @@ runs:
         # https://docs.yamory.io/35d9ca090120803f8b51d6a50d6ce3e0#block-36b9ca090120808ca7fef8760e2b106c
         echo "::group::Check Provenance"
         DIGEST=$(sha256sum "${ARTIFACT}" | cut -d' ' -f1)
-        curl -L "https://api.github.com/repos/aquasecurity/trivy/attestations/sha256:$DIGEST" | \
-        jq -r '.attestations[] | select(.initiator == "user") | .bundle' > bundle.json
+        BUNDLE_URL=$(curl -L "https://api.github.com/repos/aquasecurity/trivy/attestations/sha256:$DIGEST" | \
+          jq -r '.attestations[] | select(.initiator == "user") | .bundle_url')
+        s2d -o bundle.json -block "${BUNDLE_URL}"
         cosign verify-blob-attestation \
           --bundle bundle.json \
           --new-bundle-format \


### PR DESCRIPTION
This includes two fixes.


## Support for cosign 3.0.6


In cosign 3.0.6, explicitly specifying the attestation type became mandatory as part of the response to GHSA-w6c6-c85g-mmv6. Therefore, --type slsaprovenance1 is now explicitly specified.


## Following the breaking changes in GitHub's attestation API


The verification procedure for the trivy binary provided by yamory relied on a deprecated parameter called .bundle. Following the introduction of the changes previously announced by GitHub, verification procedures depending on this parameter no longer work.
The response for .bundle_url, which was added as an alternative, is compressed with snappy, and there is no well-known effective method for decompressing this on Linux.

We considered using gh attestation verify, but found that it cannot be used for the trivy binary due to the following issue:
https://github.com/aquasecurity/trivy/discussions/10441

Upon examining the behavior of the gh CLI, we noticed that it uses the following library:
https://github.com/klauspost/compress
The GitHub Releases for this library provide a binary for compressing and decompressing the s2 format, which is compatible with snappy. By using this, it is possible to extract the bundle.json compressed in snappy format and perform verification with the cosign command as before.
