### PR TITLE
machines-endpoints: remove PodSecurityPolicy and hostNetwork

### DIFF
--- a/machines-endpoints/machines-endpoints.yaml
+++ b/machines-endpoints/machines-endpoints.yaml
@@ -17,10 +17,6 @@ rules:
     resources:
       - endpointslices
     verbs: ["get", "list", "patch", "create", "delete"]
-  - apiGroups: ["policy"]
-    resources: ["podsecuritypolicies"]
-    verbs: ["use"]
-    resourceNames: ["machines-endpoints"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -34,53 +30,6 @@ subjects:
   - kind: ServiceAccount
     name: machines-endpoints
     namespace: default
----
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: machines-endpoints
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
-spec:
-  privileged: false
-  # Required to prevent escalations to root.
-  allowPrivilegeEscalation: false
-  # This is redundant with non-root + disallow privilege escalation,
-  # but we can provide it for defense in depth.
-  requiredDropCapabilities:
-    - ALL
-  # Allow core volume types.
-  volumes:
-    - 'configMap'
-    - 'emptyDir'
-    - 'projected'
-    - 'secret'
-    - 'downwardAPI'
-    # Assume that persistentVolumes set up by the cluster admin are safe to use.
-    - 'persistentVolumeClaim'
-  hostNetwork: true
-  hostIPC: false
-  hostPID: false
-  runAsUser:
-    # Require the container to run without root privileges.
-    rule: 'MustRunAsNonRoot'
-  seLinux:
-    # This policy assumes the nodes are using AppArmor rather than SELinux.
-    rule: 'RunAsAny'
-  supplementalGroups:
-    rule: 'MustRunAs'
-    ranges:
-      # Forbid adding the root group.
-      - min: 1
-        max: 65535
-  fsGroup:
-    rule: 'MustRunAs'
-    ranges:
-      # Forbid adding the root group.
-      - min: 1
-        max: 65535
-  readOnlyRootFilesystem: true
 ---
 apiVersion: batch/v1beta1
 kind: CronJob
@@ -104,6 +53,5 @@ spec:
                 - --boot-servers-port=2381:etcd-metrics
                 - --bmc-reverse-proxy-configmap
                 - --bmc-log-collector-configmap
-          hostNetwork: true
           restartPolicy: OnFailure
           serviceAccountName: machines-endpoints


### PR DESCRIPTION
This PR clean up the sample manifest for machines-endpoints.
This does not affect the container image, so no tag update is needed.