### PR TITLE
hubble-ui, argocd: set pnpm minimumReleaseAge to 3 days

### DIFF
--- a/argocd/Dockerfile
+++ b/argocd/Dockerfile
@@ -76,7 +76,9 @@ ENV PATH="/opt/node-v${NODE_VERSION}-linux-x64/bin:${PATH}"
 
 RUN --mount=type=bind,from=pnpm-download,source=/pnpm,target=/tmp/pnpm \
     install -m 0755 /tmp/pnpm /usr/local/bin/pnpm && \
-    pnpm config set -g minimumReleaseAge 1440
+    # 3 days, per the company-wide npm / pnpm guideline. Only used if pnpm has to
+    # resolve versions; the frozen-lockfile install below does not resolve anything.
+    pnpm config set -g minimumReleaseAge 4320
 
 RUN apt-get update && apt-get install -y --no-install-recommends gpg && \
     # Unlike upstream, do not remove /usr/share/doc/* to preserve license files

--- a/hubble-ui/Makefile
+++ b/hubble-ui/Makefile
@@ -5,6 +5,9 @@ NGINX_COMMIT_HASH ?= c743d5145c69250f030934280b01b638d9d765ed
 PNPM_DIR ?= $(CURDIR)/.pnpm-bin
 PNPM_BIN ?= $(CURDIR)/.pnpm-bin/pnpm
 TAKUMI_GUARD_REGISTRY ?= https://npm.flatt.tech/
+# Do not resolve versions published less than 3 days (4320 minutes) ago.
+# Matches the company-wide npm / pnpm security guideline.
+PNPM_MINIMUM_RELEASE_AGE ?= 4320
 
 BACKEND_BUILDER_IMAGE_TAG ?= backend-builder:dev
 BACKEND_IMAGE_TAG ?= ghcr.io/cybozu/hubble-ui-backend:$(shell cat TAG)
@@ -84,10 +87,15 @@ check-takumi-guard: $(PNPM_BIN)
 #
 # A full install (not --lockfile-only) routes every tarball through Takumi
 # Guard so the new dep set is screened before the lockfile is committed.
+#
+# minimumReleaseAge is passed explicitly instead of relying on the pnpm 11
+# default (1 day) so the waiting period stays 3 days even if the default
+# changes. Upstream ships its own .npmrc, so we do not copy one in.
 .PHONY: import-lockfile
 import-lockfile: clean check-takumi-guard checkout
 	cp ./.pnpmfile.cjs src/hubble-ui/.pnpmfile.cjs
-	cd src/hubble-ui && $(PNPM_BIN) install --no-frozen-lockfile --ignore-scripts
+	cd src/hubble-ui && $(PNPM_BIN) install --no-frozen-lockfile --ignore-scripts \
+		--config.minimumReleaseAge=$(PNPM_MINIMUM_RELEASE_AGE)
 	cp src/hubble-ui/pnpm-lock.yaml ./pnpm-lock.yaml
 
 .PHONY: verify-lockfile

--- a/maintenance.md
+++ b/maintenance.md
@@ -794,6 +794,7 @@ Hubble image is no longer built by the upstream. If failing to build the image, 
       - Browse <https://github.com/nginx/docker-nginx-unprivileged/commits/main/> .
       - `NGINX_COMMIT_HASH` should be the one referencing the commit "Update mainline NGINX to <NGINX_VERSION>".
 5. Regenerate `pnpm-lock.yaml`. Phantom deps (e.g. `@protobuf-ts/runtime`) and dep dedupes (e.g. `sass`) are injected via `hubble-ui/.pnpmfile.cjs` at manifest-read time, so the committed lockfile pins their transitive deps and the Docker build runs with `--frozen-lockfile`. `make import-lockfile` requires [Takumi Guard](https://shisho.dev/docs/ja/t/guard/quickstart/npm/) configured locally — every new tarball is fetched through the proxy for supply-chain screening, and the target refuses to start otherwise.
+   It also resolves with `minimumReleaseAge=4320` (3 days), so a version published less than 3 days ago is skipped in favor of an older one. If upstream requires such a version, wait, or pass `PNPM_MINIMUM_RELEASE_AGE=0` once and note it in the PR.
 
    ```sh
    cd hubble-ui


### PR DESCRIPTION
## What

Set the pnpm waiting period (`minimumReleaseAge`) to 3 days (4320 minutes) wherever pnpm resolves versions in this repository:

- `hubble-ui/Makefile`: pass `--config.minimumReleaseAge=$(PNPM_MINIMUM_RELEASE_AGE)` (default 4320) to the `pnpm install` in `import-lockfile`. Until now this relied on the pnpm 11 default of 1 day. Upstream ships its own `.npmrc`, so the value is passed as a flag instead of copying a config file into the checkout.
- `argocd/Dockerfile`: raise `pnpm config set -g minimumReleaseAge` from 1440 to 4320. This build installs with `--frozen-lockfile`, so the setting is only consulted if pnpm ever has to resolve; the change is for consistency and to avoid suggesting a 1-day policy.
- `maintenance.md`: note the 3-day rule in the hubble-ui lockfile procedure, and how to override it once (`PNPM_MINIMUM_RELEASE_AGE=0`) when upstream genuinely needs a version younger than 3 days.

## Why

The company-wide npm / pnpm security guideline recommends `minimumReleaseAge: 4320` (3 days) for pnpm projects so that freshly published versions are not picked up before they have had time to be inspected or pulled. The hubble-ui lockfile import is the one place in this repository where pnpm resolves new versions, and it was using the 1-day default.

## Not changed

- grafana (Yarn 4, `--immutable`) and pomerium (`npm ci`) install from upstream lockfiles and never resolve versions, so no waiting-period setting applies to them.
- No `TAG` is bumped: neither change alters image contents. The argocd value takes effect on its next regular rebuild.

## Verification

- pnpm versions in use (hubble-ui 11.1.3 via aqua, argocd 10.34.5) are above the guideline's minimum of 10.26.0 and both support `minimumReleaseAge` (added in 10.16.0).
- `make -C hubble-ui import-lockfile` was not re-run in this PR; the lockfile is unchanged. The flag only affects future lockfile regenerations.
